### PR TITLE
fix the config value of WETH in l2 genesis

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -787,7 +787,7 @@ func NewL2StorageConfig(config *DeployConfig, block *types.Block) (state.Storage
 		"_initializing": false,
 	}
 	storage["WETH"] = state.StorageValues{
-		"_name":   "Wrapped ETH",
+		"_name":   "Wrapped Ether",
 		"_symbol": "WETH",
 	}
 	return storage, nil


### PR DESCRIPTION
I have fixed the config value of WETH to resolve an issue during checking for L2 pre-deployed contracts.

the below is related log in check-l2
command: `make devnet-test`

```bash
INFO [01-16|02:28:02.749] Checking predeploy                       name=WETH                          address=0x4200000000000000000000000000000000000022
INFO [01-16|02:28:02.751] WETH                                     implementation=0xC0D3C0d3C0D3C0d3c0d3c0D3c0D3C0d3C0D30022
INFO [01-16|02:28:02.752] WETH                                     name="Wrapped Ether"
INFO [01-16|02:28:02.753] WETH                                     symbol=WETH
INFO [01-16|02:28:02.755] WETH                                     decimals=18
```
