### PR TITLE
[OR-1285] add ci for genesis to aws s3

### DIFF
--- a/.github/workflows/publish-genesis-rollup.yml
+++ b/.github/workflows/publish-genesis-rollup.yml
@@ -16,8 +16,8 @@ jobs:
       with:
         args: --acl public-read --follow-symlinks
       env:
-        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET_DEV }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_DEV }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_DEV }}
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_REGION: 'ap-northeast-2'
         SOURCE_DIR: 'packages/tokamak/contracts-bedrock/genesis'


### PR DESCRIPTION
It's pretty much the same as what we were using before.

Is there anything else I need to do?

test : https://s3.console.aws.amazon.com/s3/buckets/test-genesis-bucket-obm?region=ap-northeast-2&bucketType=general&tab=objects