### PR TITLE
OR-1534 update bindings template

### DIFF
--- a/op-bindings/gen/main.go
+++ b/op-bindings/gen/main.go
@@ -313,7 +313,9 @@ const {{.Name}}StorageLayoutJSON = "{{.StorageLayout}}"
 var {{.Name}}StorageLayout = new(solc.StorageLayout)
 
 var {{.Name}}DeployedBin = "{{.DeployedBin}}"
-
+{{if .DeployedSourceMap}}
+var {{.Name}}DeployedSourceMap = "{{.DeployedSourceMap}}"
+{{end}}
 func init() {
 	if err := json.Unmarshal([]byte({{.Name}}StorageLayoutJSON), {{.Name}}StorageLayout); err != nil {
 		panic(err)


### PR DESCRIPTION
Failed when running devnet with new generated-bindings (by cd op-bindings, "make" and start make devnet-up"

Fix: update bindings template file, refer to: https://github.com/tokamak-network/tokamak-thanos/blob/OR-1257-Update-smart-contracts-for-deposit-TON-in-L1/op-bindings/gen/main.go

I am not sure why the source map generator part was deleted. Please let me know if you have ideas.

Thank you very much! 