### PR TITLE
feat(sdk): use depositNativeToken instead of depositERC20 when depositing the native token via L1 Bridge

### DIFF
--- a/packages/tokamak/sdk/src/adapters/native-token-bridge.ts
+++ b/packages/tokamak/sdk/src/adapters/native-token-bridge.ts
@@ -218,18 +218,14 @@ export class NativeTokenBridgeAdapter extends StandardBridgeAdapter {
 
       // NOTE: don't set the "value" because on ETH is native token in L1
       if (opts?.recipient === undefined) {
-        return this.l1Bridge.populateTransaction.depositERC20(
-          toAddress(l1Token),
-          toAddress(l2Token),
+        return this.l1Bridge.populateTransaction.depositNativeToken(
           amount,
           opts?.l2GasLimit || 200_000, // Default to 200k gas limit.
           '0x', // No data.
           opts?.overrides || {}
         )
       } else {
-        return this.l1Bridge.populateTransaction.depositERC20To(
-          toAddress(l1Token),
-          toAddress(l2Token),
+        return this.l1Bridge.populateTransaction.depositNativeTokenTo(
           toAddress(opts.recipient),
           amount,
           opts?.l2GasLimit || 200_000, // Default to 200k gas limit.


### PR DESCRIPTION
Use `depositNativeToken`function  when depositing the native token via the L1 Bridge