### PR TITLE
Or 1567 thanos cannon setup timeout for ec2 runner

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -47,7 +47,7 @@ jobs:
     needs: [start-runner-ws]
     runs-on: ${{ needs.start-runner-ws.outputs.label }}
     steps:
-      - name: set timeout
+      - name: update shutdown behavior
         run: |
           aws ec2 modify-instance-attribute --instance-initiated-shutdown-behavior terminate --instance-id ${{ needs.start-runner-ws.outputs.ec2-instance-id }}
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,5 +1,5 @@
 name: 'Tokamak End to End Test'
-on: push
+on: pull_request
 
 jobs:
   start-runner-ws:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,5 +1,5 @@
 name: 'Tokamak End to End Test'
-on: pull_request
+on: push
 
 jobs:
   start-runner-ws:
@@ -16,52 +16,50 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ap-northeast-2
 
+      - name: Install aws
+        id: install-aws-cli
+        uses: unfor19/install-aws-cli-action@master
+
+      - run: aws --version
+        shell: bash
+
       - name: Start EC2 runner
         id: start-ec2-runner
         uses: machulav/ec2-github-runner@v2
         with:
           mode: start
           github-token: ${{ secrets.ACCESS_TOKEN }}
-          ec2-image-id: ami-01bd9dc38789ab007
+          ec2-image-id: ami-01f36d9fbf17b3974
           ec2-instance-type: c7g.4xlarge
           subnet-id: subnet-4aa53021
           security-group-id: sg-03165a21a3ba6e8b3
+          iam-role-name: ec2-runner
+          pre-runner-script: shutdown -P +40
+
       - name: Runner status
         id: status
         run: |
           echo "Runner label:" ${{ steps.start-ec2-runner.outputs.label }}
           echo "EC2 instances id:" ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
 
-  stop-runner-ws:
-    name: Stop self-hosted EC2 runner for ws tests
-    needs: [start-runner-ws, ws-e2e-tests]
-    runs-on: ubuntu-latest
-    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
+  ws-e2e-update:
+    name: 'ec2 update attribute for ws test'
+    needs: [start-runner-ws]
+    runs-on: ${{ needs.start-runner-ws.outputs.label }}
     steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ap-northeast-2
-
-      - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2
-        with:
-          mode: stop
-          github-token: ${{ secrets.ACCESS_TOKEN }}
-          label: ${{ needs.start-runner-ws.outputs.label }}
-          ec2-instance-id: ${{ needs.start-runner-ws.outputs.ec2-instance-id }}
+      - name: set timeout
+        run: |
+          aws ec2 modify-instance-attribute --instance-initiated-shutdown-behavior terminate --instance-id ${{ needs.start-runner-ws.outputs.ec2-instance-id }}
 
   ws-e2e-tests:
     name: 'ws e2e test'
-    needs: [start-runner-ws]
+    needs: [ws-e2e-update, start-runner-ws]
     runs-on: ${{ needs.start-runner-ws.outputs.label }}
     container:
       image: onthertech/thanos-ci-builder:latest
     steps:
       - name: Check CPUs
-        run: lscpu
+        run: lscpu && echo
 
       - name: Checkout
         uses: actions/checkout@v4.1.0
@@ -98,6 +96,27 @@ jobs:
         run: OP_TESTLOG_DISABLE_COLOR=true OP_E2E_DISABLE_PARALLEL=false gotestsum --format=standard-verbose -- -timeout=25m -parallel=16 ./...
         working-directory: op-e2e
 
+  stop-runner-ws:
+    name: Stop self-hosted EC2 runner for ws tests
+    needs: [start-runner-ws, ws-e2e-tests]
+    runs-on: ubuntu-latest
+    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      - name: Stop EC2 runner
+        uses: machulav/ec2-github-runner@v2
+        with:
+          mode: stop
+          github-token: ${{ secrets.ACCESS_TOKEN }}
+          label: ${{ needs.start-runner-ws.outputs.label }}
+          ec2-instance-id: ${{ needs.start-runner-ws.outputs.ec2-instance-id }}
+
   start-runner-http:
     name: Start EC2 Runner for http tests
     runs-on: ubuntu-latest
@@ -118,40 +137,31 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.ACCESS_TOKEN }}
-          ec2-image-id: ami-01bd9dc38789ab007
+          ec2-image-id: ami-01f36d9fbf17b3974
           ec2-instance-type: c7g.4xlarge
           subnet-id: subnet-4aa53021
           security-group-id: sg-03165a21a3ba6e8b3
+          iam-role-name: ec2-runner
+          pre-runner-script: shutdown -P +40
+
       - name: Runner status
         id: status
         run: |
           echo "Runner label:" ${{ steps.start-ec2-runner.outputs.label }}
           echo "EC2 instances id:" ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
 
-  stop-runner-http:
-    name: Stop self-hosted EC2 runner for http tests
-    needs: [start-runner-http, http-e2e-tests]
-    runs-on: ubuntu-latest
-    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
+  http-e2e-update:
+    name: 'ec2 update attribute for http test'
+    needs: [start-runner-http]
+    runs-on: ${{ needs.start-runner-http.outputs.label }}
     steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ap-northeast-2
-
-      - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2
-        with:
-          mode: stop
-          github-token: ${{ secrets.ACCESS_TOKEN }}
-          label: ${{ needs.start-runner-http.outputs.label }}
-          ec2-instance-id: ${{ needs.start-runner-http.outputs.ec2-instance-id }}
+      - name: set timeout
+        run: |
+          aws ec2 modify-instance-attribute --instance-initiated-shutdown-behavior terminate --instance-id ${{ needs.start-runner-http.outputs.ec2-instance-id }}
 
   http-e2e-tests:
     name: 'http-e2e test'
-    needs: [start-runner-http]
+    needs: [http-e2e-update, start-runner-http]
     runs-on: ${{ needs.start-runner-http.outputs.label }}
     container:
       image: onthertech/thanos-ci-builder:latest
@@ -193,3 +203,24 @@ jobs:
       - name: Run e2e http test
         run: OP_E2E_USE_HTTP=true OP_TESTLOG_DISABLE_COLOR=true OP_E2E_DISABLE_PARALLEL=false gotestsum --format=standard-verbose -- -timeout=25m -parallel=16 ./...
         working-directory: op-e2e
+
+  stop-runner-http:
+    name: Stop self-hosted EC2 runner for http tests
+    needs: [start-runner-http, http-e2e-tests]
+    runs-on: ubuntu-latest
+    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      - name: Stop EC2 runner
+        uses: machulav/ec2-github-runner@v2
+        with:
+          mode: stop
+          github-token: ${{ secrets.ACCESS_TOKEN }}
+          label: ${{ needs.start-runner-http.outputs.label }}
+          ec2-instance-id: ${{ needs.start-runner-http.outputs.ec2-instance-id }}

--- a/.github/workflows/release-docker-nightly.yml
+++ b/.github/workflows/release-docker-nightly.yml
@@ -1,6 +1,9 @@
 name: Publish Docker images (nightly)
 
-on: push
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   version:

--- a/.github/workflows/release-docker-nightly.yml
+++ b/.github/workflows/release-docker-nightly.yml
@@ -1,9 +1,6 @@
 name: Publish Docker images (nightly)
 
-on:
-  push:
-    branches:
-      - main
+on: push
 
 jobs:
   version:

--- a/.github/workflows/release-docker-nightly.yml
+++ b/.github/workflows/release-docker-nightly.yml
@@ -167,10 +167,12 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.ACCESS_TOKEN }}
-          ec2-image-id: ami-01bd9dc38789ab007
+          ec2-image-id: ami-01f36d9fbf17b3974
           ec2-instance-type: t4g.2xlarge
           subnet-id: subnet-4aa53021
           security-group-id: sg-03165a21a3ba6e8b3
+          iam-role-name: ec2-runner
+          pre-runner-script: shutdown -P +40
 
       - name: Runner status
         id: status
@@ -198,6 +200,18 @@ jobs:
         id: read
         with:
           matrix-step-name: start-runners
+
+  ec2-update-arm64:
+    name: Update EC2 ${{ fromJson(needs.runners.outputs.result).ec2-instance-id[format('{0}', matrix.number)] }}
+    needs: [runners, version]
+    strategy:
+      matrix:
+        number: [0, 1, 2, 3, 4]
+    runs-on: ${{ fromJson(needs.runners.outputs.result).label[format('{0}', matrix.number)] }}
+    steps:
+      - name: update shutdown behavior
+        run: |
+          aws ec2 modify-instance-attribute --instance-initiated-shutdown-behavior terminate --instance-id ${{ fromJson(needs.runners.outputs.result).ec2-instance-id[format('{0}', matrix.number)] }}
 
   chain-mon-amd64:
     name: Publish ${{ matrix.target }}
@@ -243,7 +257,7 @@ jobs:
 
   chain-mon-arm64:
     name: Publish ${{ matrix.target }}
-    needs: [runners, version]
+    needs: [runners, ec2-update-arm64, version]
     runs-on: ${{ fromJson(needs.runners.outputs.result).label[format('{0}', matrix.number)] }}
     strategy:
       matrix:

--- a/.github/workflows/release-docker-release.yml
+++ b/.github/workflows/release-docker-release.yml
@@ -199,6 +199,18 @@ jobs:
         with:
           matrix-step-name: start-runners
 
+  ec2-update-arm64:
+    name: Update EC2 ${{ fromJson(needs.runners.outputs.result).ec2-instance-id[format('{0}', matrix.number)] }}
+    needs: [runners, version]
+    strategy:
+      matrix:
+        number: [0, 1, 2, 3, 4]
+    runs-on: ${{ fromJson(needs.runners.outputs.result).label[format('{0}', matrix.number)] }}
+    steps:
+      - name: update shutdown behavior
+        run: |
+          aws ec2 modify-instance-attribute --instance-initiated-shutdown-behavior terminate --instance-id ${{ fromJson(needs.runners.outputs.result).ec2-instance-id[format('{0}', matrix.number)] }}
+
   chain-mon-amd64:
     name: Publish ${{ matrix.target }}
     needs: [version]
@@ -243,7 +255,7 @@ jobs:
 
   chain-mon-arm64:
     name: Publish ${{ matrix.target }}
-    needs: [runners, version]
+    needs: [runners, ec2-update-arm64, version]
     runs-on: ${{ fromJson(needs.runners.outputs.result).label[format('{0}', matrix.number)] }}
     strategy:
       matrix:

--- a/.github/workflows/tokamak-contract-bedrock-test.yml
+++ b/.github/workflows/tokamak-contract-bedrock-test.yml
@@ -1,5 +1,9 @@
 name: 'Tokamak Contract Bedrock Test'
-on: push
+on:
+  pull_request:
+    paths:
+      - 'op-node/**'
+      - 'packages/tokamak/contracts-bedrock/**'
 
 jobs:
   start-runner:

--- a/.github/workflows/tokamak-contract-bedrock-test.yml
+++ b/.github/workflows/tokamak-contract-bedrock-test.yml
@@ -1,9 +1,6 @@
 name: 'Tokamak Contract Bedrock Test'
-on:
-  pull_request:
-    paths:
-      - 'op-node/**'
-      - 'packages/tokamak/contracts-bedrock/**'
+on: push
+
 jobs:
   start-runner:
     name: Start EC2 Runner

--- a/.github/workflows/tokamak-contract-bedrock-test.yml
+++ b/.github/workflows/tokamak-contract-bedrock-test.yml
@@ -25,6 +25,7 @@ jobs:
           ec2-instance-type: t4g.2xlarge
           subnet-id: subnet-4aa53021
           security-group-id: sg-03165a21a3ba6e8b3
+          iam-role-name: ec2-runner
           pre-runner-script: shutdown -P +40
       - name: Runner status
         id: status

--- a/.github/workflows/tokamak-contract-bedrock-test.yml
+++ b/.github/workflows/tokamak-contract-bedrock-test.yml
@@ -37,9 +37,9 @@ jobs:
     needs: [start-runner]
     runs-on: ${{ needs.start-runner.outputs.label }}
     steps:
-      - name: set timeout
+      - name: update shutdown behavior
         run: |
-          aws ec2 modify-instance-attribute --instance-initiated-shutdown-behavior terminate --instance-id ${{ needs.start-runner-http.outputs.ec2-instance-id }}
+          aws ec2 modify-instance-attribute --instance-initiated-shutdown-behavior terminate --instance-id ${{ needs.start-runner.outputs.ec2-instance-id }}
 
   stop-runner:
     name: Stop self-hosted EC2 runner

--- a/.github/workflows/tokamak-contract-bedrock-test.yml
+++ b/.github/workflows/tokamak-contract-bedrock-test.yml
@@ -24,15 +24,25 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.ACCESS_TOKEN }}
-          ec2-image-id: ami-01bd9dc38789ab007
+          ec2-image-id: ami-01f36d9fbf17b3974
           ec2-instance-type: t4g.2xlarge
           subnet-id: subnet-4aa53021
           security-group-id: sg-03165a21a3ba6e8b3
+          pre-runner-script: shutdown -P +40
       - name: Runner status
         id: status
         run: |
           echo "Runner label:" ${{ steps.start-ec2-runner.outputs.label }}
           echo "EC2 instances id:" ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+
+  ec2-update-attribute:
+    name: Update EC2 shutdown behavior
+    needs: [start-runner]
+    runs-on: ${{ needs.start-runner.outputs.label }}
+    steps:
+      - name: set timeout
+        run: |
+          aws ec2 modify-instance-attribute --instance-initiated-shutdown-behavior terminate --instance-id ${{ needs.start-runner-http.outputs.ec2-instance-id }}
 
   stop-runner:
     name: Stop self-hosted EC2 runner
@@ -57,7 +67,7 @@ jobs:
 
   contracts-bedrock-tests:
     name: 'Contract Bedrock test'
-    needs: [start-runner]
+    needs: [start-runner, ec2-update-attribute]
     runs-on: ${{ needs.start-runner.outputs.label }}
     container:
       image: onthertech/thanos-ci-builder:latest


### PR DESCRIPTION
- Add timeout for EC2: we need to update the Shutdown behavior so EC2 instances will be terminated automatically after shutting down. 
- Make AWS role so that can change EC2 attribute setting

One remaining thing is: we still need to remove Github Runner config manually, because there is no support from machulav/ec2-github-runner@v2 to get Token to remove Runner, but we can fork this branch and make changed code. 

I tested on: https://github.com/tokamak-network/tokamak-thanos/tree/OR-1567-test

Thank you!