### PR TITLE
Or 1621 check predeploys of usdc bridge

### DIFF
--- a/op-bindings/bindings/registry.go
+++ b/op-bindings/bindings/registry.go
@@ -61,6 +61,9 @@ func GetDeployedBytecode(name string) ([]byte, error) {
 
 // HasImmutableReferences returns the immutable references of a contract by name.
 func HasImmutableReferences(name string) (bool, error) {
+	if name == "MasterMinter" {
+		return true, nil
+	}
 	has, ok := immutableReferences[name]
 	if !ok {
 		return false, fmt.Errorf("%s: immutable reference not found", name)

--- a/op-bindings/predeploys/addresses.go
+++ b/op-bindings/predeploys/addresses.go
@@ -141,7 +141,7 @@ func init() {
 	Predeploys["L2UsdcBridge"] = &Predeploy{Address: L2UsdcBridgeAddr}
 	Predeploys["SignatureChecker"] = &Predeploy{Address: SignatureCheckerAddr, ProxyDisabled: true}
 	Predeploys["MasterMinter"] = &Predeploy{Address: MasterMinterAddr, ProxyDisabled: true}
-	Predeploys["FiatTokenV2_2"] = &Predeploy{Address: FiatTokenV2_2Addr, ProxyDisabled: true}
+	Predeploys["FiatTokenV2_2"] = &Predeploy{Address: FiatTokenV2_2Addr}
 
 	Predeploys["Create2Deployer"] = &Predeploy{
 		Address:       Create2DeployerAddr,

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -880,8 +880,12 @@ func NewL2ImmutableConfig(config *DeployConfig, block *types.Block) (*immutables
 		},
 		L2UsdcBridge:     struct{}{},
 		SignatureChecker: struct{}{},
-		MasterMinter:     struct{}{},
-		FiatTokenV2_2:    struct{}{},
+		MasterMinter: struct {
+			MinterManager common.Address
+		}{
+			MinterManager: predeploys.FiatTokenV2_2Addr,
+		},
+		FiatTokenV2_2: struct{}{},
 	}
 
 	if err := cfg.Check(); err != nil {

--- a/op-chain-ops/genesis/layer_two.go
+++ b/op-chain-ops/genesis/layer_two.go
@@ -112,7 +112,13 @@ func BuildL2Genesis(config *DeployConfig, l1StartBlock *types.Block) (*core.Gene
 			bytecode = c
 			deployResults[name] = bytecode
 		case "FiatTokenV2_2":
+			codeAddr, err = AddressToCodeNamespace(predeploy.Address)
+			if err != nil {
+				return nil, fmt.Errorf("error converting to code namespace: %w", err)
+			}
+			db.CreateAccount(codeAddr)
 			db.SetState(predeploy.Address, ImplementationSlotForZepplin, eth.AddressAsLeftPaddedHash(codeAddr))
+			log.Info("Set proxy for FiatTokenV2_2", "name", name, "address", predeploy.Address, "implementation", codeAddr)
 		default:
 			if !predeploy.ProxyDisabled {
 				codeAddr, err = AddressToCodeNamespace(predeploy.Address)

--- a/op-chain-ops/genesis/layer_two.go
+++ b/op-chain-ops/genesis/layer_two.go
@@ -1,10 +1,12 @@
 package genesis
 
 import (
+	"encoding/hex"
 	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
@@ -95,6 +97,20 @@ func BuildL2Genesis(config *DeployConfig, l1StartBlock *types.Block) (*core.Gene
 			"SafeL2_v130", "MultiSendCallOnly_v130", "SafeSingletonFactory",
 			"DeterministicDeploymentProxy", "MultiSend_v130", "SenderCreator", "EntryPoint":
 			db.CreateAccount(codeAddr)
+		case "SignatureChecker":
+			bytecode, err := bindings.GetDeployedBytecode(name)
+			if err != nil {
+				return nil, err
+			}
+			a := bytecode[:1]
+			b := bytecode[21:]
+			c := hexutil.Bytes{}
+			d, _ := hex.DecodeString("4200000000000000000000000000000000000776")
+			c = append(c, a...)
+			c = append(c, d...)
+			c = append(c, b...)
+			bytecode = c
+			deployResults[name] = bytecode
 		case "FiatTokenV2_2":
 			db.SetState(predeploy.Address, ImplementationSlotForZepplin, eth.AddressAsLeftPaddedHash(codeAddr))
 		default:

--- a/op-chain-ops/immutables/immutables.go
+++ b/op-chain-ops/immutables/immutables.go
@@ -216,16 +216,24 @@ func l2ImmutableDeployer(backend *backends.SimulatedBackend, opts *bind.Transact
 	}
 
 	switch deployment.Name {
-	case "L2CrossDomainMessenger":
-		_, tx, _, err = bindings.DeployL2CrossDomainMessenger(opts, backend)
-	case "L2StandardBridge":
-		_, tx, _, err = bindings.DeployL2StandardBridge(opts, backend)
+	case "LegacyERC20NativeToken":
+		_, tx, _, err = bindings.DeployLegacyERC20NativeToken(opts, backend)
 	case "SequencerFeeVault":
 		recipient, minimumWithdrawalAmount, withdrawalNetwork, err = prepareFeeVaultArguments(deployment)
 		if err != nil {
 			return nil, err
 		}
 		_, tx, _, err = bindings.DeploySequencerFeeVault(opts, backend, recipient, minimumWithdrawalAmount, withdrawalNetwork)
+	case "OptimismMintableERC721Factory":
+		bridge, ok := deployment.Args[0].(common.Address)
+		if !ok {
+			return nil, fmt.Errorf("invalid type for bridge")
+		}
+		remoteChainId, ok := deployment.Args[1].(*big.Int)
+		if !ok {
+			return nil, fmt.Errorf("invalid type for remoteChainId")
+		}
+		_, tx, _, err = bindings.DeployOptimismMintableERC721Factory(opts, backend, bridge, remoteChainId)
 	case "BaseFeeVault":
 		recipient, minimumWithdrawalAmount, withdrawalNetwork, err = prepareFeeVaultArguments(deployment)
 		if err != nil {
@@ -238,38 +246,16 @@ func l2ImmutableDeployer(backend *backends.SimulatedBackend, opts *bind.Transact
 			return nil, err
 		}
 		_, tx, _, err = bindings.DeployL1FeeVault(opts, backend, recipient, minimumWithdrawalAmount, withdrawalNetwork)
-	case "OptimismMintableERC20Factory":
-		_, tx, _, err = bindings.DeployOptimismMintableERC20Factory(opts, backend)
-	case "L2ERC721Bridge":
-		_, tx, _, err = bindings.DeployL2ERC721Bridge(opts, backend)
-	case "OptimismMintableERC721Factory":
-		bridge, ok := deployment.Args[0].(common.Address)
-		if !ok {
-			return nil, fmt.Errorf("invalid type for bridge")
-		}
-		remoteChainId, ok := deployment.Args[1].(*big.Int)
-		if !ok {
-			return nil, fmt.Errorf("invalid type for remoteChainId")
-		}
-		_, tx, _, err = bindings.DeployOptimismMintableERC721Factory(opts, backend, bridge, remoteChainId)
-	case "LegacyERC20NativeToken":
-		_, tx, _, err = bindings.DeployLegacyERC20NativeToken(opts, backend)
 	case "EAS":
 		_, tx, _, err = bindings.DeployEAS(opts, backend)
 	case "ETH":
 		_, tx, _, err = bindings.DeployETH(opts, backend)
-	case "L2UsdcBridge":
-		_, tx, _, err = bindings.DeployL2UsdcBridge(opts, backend)
-	case "SignatureChecker":
-		_, tx, _, err = bindings.DeploySignatureChecker(opts, backend)
 	case "MasterMinter":
 		_minterManager, ok := deployment.Args[0].(common.Address)
 		if !ok {
 			return nil, fmt.Errorf("invalid type for _minterManager")
 		}
 		_, tx, _, err = bindings.DeployMasterMinter(opts, backend, _minterManager)
-	case "FiatTokenV2_2":
-		_, tx, _, err = bindings.DeployFiatTokenV22(opts, backend)
 	default:
 		return tx, fmt.Errorf("unknown contract: %s", deployment.Name)
 	}

--- a/op-chain-ops/immutables/immutables.go
+++ b/op-chain-ops/immutables/immutables.go
@@ -65,9 +65,11 @@ type PredeploysImmutableConfig struct {
 		Bridge      common.Address
 		Decimals    uint8
 	}
-	L2UsdcBridge                       struct{}
-	SignatureChecker                   struct{}
-	MasterMinter                       struct{}
+	L2UsdcBridge     struct{}
+	SignatureChecker struct{}
+	MasterMinter     struct {
+		MinterManager common.Address
+	}
 	FiatTokenV2_2                      struct{}
 	QuoterV2                           struct{}
 	SwapRouter02                       struct{}

--- a/op-chain-ops/immutables/immutables_test.go
+++ b/op-chain-ops/immutables/immutables_test.go
@@ -84,9 +84,13 @@ func TestBuildOptimism(t *testing.T) {
 			Bridge:      predeploys.L2StandardBridgeAddr,
 			Decimals:    18,
 		},
-		L2UsdcBridge:                       struct{}{},
-		SignatureChecker:                   struct{}{},
-		MasterMinter:                       struct{}{},
+		L2UsdcBridge:     struct{}{},
+		SignatureChecker: struct{}{},
+		MasterMinter: struct {
+			MinterManager common.Address
+		}{
+			MinterManager: predeploys.FiatTokenV2_2Addr,
+		},
 		FiatTokenV2_2:                      struct{}{},
 		QuoterV2:                           struct{}{},
 		SwapRouter02:                       struct{}{},


### PR DESCRIPTION
Hello Everyone
I checked after the Thanos Ecotone update regarding UsdcBridge.

- changed the SignatureChecker's Deployedbytecode to include SignatureChecker's predeploy address. 
I think this is an inevitable process in Predeploy.

- changed immutables.go, immutables_test.go and config.go for MasterMinter's constructor.

- deleted the unrelated case statement from the l2ImmutableDeployer function.

- changed the layer_two.go because the implementation Address of FiatTokenProxy was not set.