### PR TITLE
fix(op-bindings): change type of DeployedBytecode to interface to support dynamic types

### DIFF
--- a/op-bindings/hardhat/types.go
+++ b/op-bindings/hardhat/types.go
@@ -20,18 +20,18 @@ type DeployedBytecodeObject struct {
 // Deployment represents a hardhat-deploy artifact file
 type Deployment struct {
 	Name             string
-	Abi              abi.ABI                `json:"abi"`
-	Address          common.Address         `json:"address"`
-	Args             []interface{}          `json:"-"`
-	Bytecode         hexutil.Bytes          `json:"bytecode"`
-	DeployedBytecode DeployedBytecodeObject `json:"deployedBytecode"`
-	Devdoc           json.RawMessage        `json:"devdoc"`
-	Metadata         string                 `json:"metadata"`
-	Receipt          json.RawMessage        `json:"receipt"`
-	SolcInputHash    string                 `json:"solcInputHash"`
-	StorageLayout    solc.StorageLayout     `json:"storageLayout"`
-	TransactionHash  common.Hash            `json:"transactionHash"`
-	Userdoc          json.RawMessage        `json:"userdoc"`
+	Abi              abi.ABI            `json:"abi"`
+	Address          common.Address     `json:"address"`
+	Args             []interface{}      `json:"-"`
+	Bytecode         hexutil.Bytes      `json:"bytecode"`
+	DeployedBytecode interface{}        `json:"deployedBytecode"`
+	Devdoc           json.RawMessage    `json:"devdoc"`
+	Metadata         string             `json:"metadata"`
+	Receipt          json.RawMessage    `json:"receipt"`
+	SolcInputHash    string             `json:"solcInputHash"`
+	StorageLayout    solc.StorageLayout `json:"storageLayout"`
+	TransactionHash  common.Hash        `json:"transactionHash"`
+	Userdoc          json.RawMessage    `json:"userdoc"`
 }
 
 // UnmarshalJSON is a custom unmarshaler for Deployment, handling the Args field. This changed recently


### PR DESCRIPTION
@AaronLee22 changed the type of `DeployedBytecode` from `[]byte` to `DeployedBytecode` struct in this [PR](https://github.com/tokamak-network/tokamak-thanos/pull/177/files#diff-38ab4d92d3f7c9f8e3c4446d1227ce60491adecf99c5b3477f368ef0d50d4852L20)

But we support both string and struct with this field. I faced the error when running `gotest` with the `op-bindings` folder because in the deployments this field is a string value.