### PR TITLE
[OR-1842] feat: devnet custom L2 chain id

### DIFF
--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -250,10 +250,12 @@ def devnet_l2_allocs(paths):
       'DEPLOY_CONFIG_PATH': paths.devnet_config_path,
     }, cwd=paths.contracts_bedrock_dir)
 
+    deploy_config = read_json(paths.devnet_config_path)
+    l2_chain_id = deploy_config['l2ChainID']
     # For the previous forks, and the latest fork (default, thus empty prefix),
     # move the forge-dumps into place as .devnet allocs.
     for suffix in ["-delta", "-ecotone", ""]:
-        input_path = pjoin(paths.contracts_bedrock_dir, f"state-dump-901{suffix}.json")
+        input_path = pjoin(paths.contracts_bedrock_dir, f"state-dump-{l2_chain_id}{suffix}.json")
         output_path = pjoin(paths.devnet_dir, f'allocs-l2{suffix}.json')
         shutil.move(src=input_path, dst=output_path)
         log.info("Generated L2 allocs: "+output_path)


### PR DESCRIPTION
In on-demand service, provide custom l2 chain id for devnet deploy.

when current scripts findig state-dump file that the file name is fixed state-dump-901.

So, check the chainid in deploy-config and proceed to the next step.