### PR TITLE
Or 1871 analyze l1 xdm gas cost for relay message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,145 +1,28 @@
-<div align="center">
-  <br />
-  <br />
-  <a href="https://optimism.io"><img alt="Optimism" src="https://raw.githubusercontent.com/ethereum-optimism/brand-kit/main/assets/svg/OPTIMISM-R.svg" width=600></a>
-  <br />
-  <h3><a href="https://optimism.io">Optimism</a> is Ethereum, scaled.</h3>
-  <br />
-</div>
+THis PR is for analyzing gas cost in L1CrossDomainMessenger.relayMessage.
 
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**
+Testing method:
+- Run Devnet
+- Unittest
 
-- [What is Optimism?](#what-is-optimism)
-- [Documentation](#documentation)
-- [Specification](#specification)
-- [Community](#community)
-- [Contributing](#contributing)
-- [Security Policy and Vulnerability Reporting](#security-policy-and-vulnerability-reporting)
-- [Directory Structure](#directory-structure)
-- [Development and Release Process](#development-and-release-process)
-  - [Overview](#overview)
-  - [Production Releases](#production-releases)
-  - [Development branch](#development-branch)
-- [License](#license)
+What we want here is the call L1CrossDomainMessenger.relayMessage from OptimismPortal cannot be reverted.
+If the call reverts, token will be locked in OptimismPortal and relayMessage cannot be successful. It could happen if L1CrossDomainMessenger.relayMessage run out-of-gas in its context. By this test, we will check how many gas is used for relayMessage()
 
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+The tests show that relayMessage only takes less than 100K gas and gas cost after the external call is executed is ~25K gas (RELAY_RESERVED_GAS = 40_000). So we don't have any issues relates to gas here.
 
-## What is Optimism?
+However, RELAY_GAS_CHECK_BUFFER needs to be increased to 35_000 from 5000 because the gas cost after SafeCall.hasMinGas until the external call is increasing by ~27K gas (The call still succeeds because the total gas provided by OptimismPortal ~300K gas)
 
-[Optimism](https://www.optimism.io/) is a project dedicated to scaling Ethereum's technology and expanding its ability to coordinate people from across the world to build effective decentralized economies and governance systems. The [Optimism Collective](https://app.optimism.io/announcement) builds open-source software for running L2 blockchains and aims to address key governance and economic challenges in the wider cryptocurrency ecosystem. Optimism operates on the principle of **impact=profit**, the idea that individuals who positively impact the Collective should be proportionally rewarded with profit. **Change the incentives and you change the world.**
+Let explain why there is not much extra gas in relayMessage? Because Thanos has used gas optimization techniques, such as resetting storage values to their original state, or clear the storage values or leverage warm accessed objects.
 
-In this repository, you'll find numerous core components of the OP Stack, the decentralized software stack maintained by the Optimism Collective that powers Optimism and forms the backbone of blockchains like [OP Mainnet](https://explorer.optimism.io/) and [Base](https://base.org). Designed to be "aggressively open source," the OP Stack encourages you to explore, modify, extend, and test the code as needed. Although not all elements of the OP Stack are contained here, many of its essential components can be found within this repository. By collaborating on free, open software and shared standards, the Optimism Collective aims to prevent siloed software development and rapidly accelerate the development of the Ethereum ecosystem. Come contribute, build the future, and redefine power, together.
+For example the code below:
 
-## Documentation
+```
+    if (_value != 0 && _target != address(0)) {
+        IERC20(_nativeTokenAddress).approve(_target, 0);
+    }
+```
+- The contract L2 native token is called again so it is a warm access.
+- And we try to clear the approval storage. If the storage value is 0 already, the gas cost is low.
 
-- If you want to build on top of OP Mainnet, refer to the [Optimism Documentation](https://docs.optimism.io)
-- If you want to build your own OP Stack based blockchain, refer to the [OP Stack Guide](https://docs.optimism.io/stack/getting-started), and make sure to understand this repository's [Development and Release Process](#development-and-release-process)
+We can visit the doc that explain opcode SSTORE at https://ethereum.org/en/developers/docs/evm/opcodes/
+And: https://github.com/wolflo/evm-opcodes/blob/main/gas.md#a7-sstore
 
-## Specification
-
-If you're interested in the technical details of how Optimism works, refer to the [Optimism Protocol Specification](https://github.com/ethereum-optimism/specs).
-
-## Community
-
-General discussion happens most frequently on the [Optimism discord](https://discord.gg/optimism).
-Governance discussion can also be found on the [Optimism Governance Forum](https://gov.optimism.io/).
-
-## Contributing
-
-Read through [CONTRIBUTING.md](./CONTRIBUTING.md) for a general overview of the contributing process for this repository.
-Use the [Developer Quick Start](./CONTRIBUTING.md#development-quick-start) to get your development environment set up to start working on the Optimism Monorepo.
-Then check out the list of [Good First Issues](https://github.com/ethereum-optimism/optimism/issues?q=is:open+is:issue+label:D-good-first-issue) to find something fun to work on!
-Typo fixes are welcome; however, please create a single commit with all of the typo fixes & batch as many fixes together in a PR as possible. Spammy PRs will be closed.
-
-## Security Policy and Vulnerability Reporting
-
-Please refer to the canonical [Security Policy](https://github.com/ethereum-optimism/.github/blob/master/SECURITY.md) document for detailed information about how to report vulnerabilities in this codebase.
-Bounty hunters are encouraged to check out [the Optimism Immunefi bug bounty program](https://immunefi.com/bounty/optimism/).
-The Optimism Immunefi program offers up to $2,000,042 for in-scope critical vulnerabilities.
-
-## Directory Structure
-
-<pre>
-├── <a href="./docs">docs</a>: A collection of documents including audits and post-mortems
-├── <a href="./op-batcher">op-batcher</a>: L2-Batch Submitter, submits bundles of batches to L1
-├── <a href="./op-bootnode">op-bootnode</a>: Standalone op-node discovery bootnode
-├── <a href="./op-chain-ops">op-chain-ops</a>: State surgery utilities
-├── <a href="./op-challenger">op-challenger</a>: Dispute game challenge agent
-├── <a href="./op-e2e">op-e2e</a>: End-to-End testing of all bedrock components in Go
-├── <a href="./op-heartbeat">op-heartbeat</a>: Heartbeat monitor service
-├── <a href="./op-node">op-node</a>: rollup consensus-layer client
-├── <a href="./op-preimage">op-preimage</a>: Go bindings for Preimage Oracle
-├── <a href="./op-program">op-program</a>: Fault proof program
-├── <a href="./op-proposer">op-proposer</a>: L2-Output Submitter, submits proposals to L1
-├── <a href="./op-service">op-service</a>: Common codebase utilities
-├── <a href="./op-ufm">op-ufm</a>: Simulations for monitoring end-to-end transaction latency
-├── <a href="./op-wheel">op-wheel</a>: Database utilities
-├── <a href="./ops">ops</a>: Various operational packages
-├── <a href="./ops-bedrock">ops-bedrock</a>: Bedrock devnet work
-├── <a href="./packages">packages</a>
-│   ├── <a href="./packages/chain-mon">chain-mon</a>: Chain monitoring services
-│   ├── <a href="./packages/contracts-bedrock">contracts-bedrock</a>: Bedrock smart contracts
-│   ├── <a href="./packages/sdk">sdk</a>: provides a set of tools for interacting with Optimism
-├── <a href="./proxyd">proxyd</a>: Configurable RPC request router and proxy
-├── <a href="./specs">specs</a>: Specs of the rollup starting at the Bedrock upgrade
-</pre>
-
-## Development and Release Process
-
-### Overview
-
-Please read this section if you're planning to fork this repository, or make frequent PRs into this repository.
-
-### Production Releases
-
-Production releases are always tags, versioned as `<component-name>/v<semver>`.
-For example, an `op-node` release might be versioned as `op-node/v1.1.2`, and  smart contract releases might be versioned as `op-contracts/v1.0.0`.
-Release candidates are versioned in the format `op-node/v1.1.2-rc.1`.
-We always start with `rc.1` rather than `rc`.
-
-For contract releases, refer to the GitHub release notes for a given release, which will list the specific contracts being released—not all contracts are considered production ready within a release, and many are under active development.
-
-Tags of the form `v<semver>`, such as `v1.1.4`, indicate releases of all Go code only, and **DO NOT** include smart contracts.
-This naming scheme is required by Golang.
-In the above list, this means these `v<semver` releases contain all `op-*` components, and exclude all `contracts-*` components.
-
-`op-geth` embeds upstream geth’s version inside it’s own version as follows: `vMAJOR.GETH_MAJOR GETH_MINOR GETH_PATCH.PATCH`.
-Basically, geth’s version is our minor version.
-For example if geth is at `v1.12.0`, the corresponding op-geth version would be `v1.101200.0`.
-Note that we pad out to three characters for the geth minor version and two characters for the geth patch version.
-Since we cannot left-pad with zeroes, the geth major version is not padded.
-
-See the [Node Software Releases](https://docs.optimism.io/builders/node-operators/releases) page of the documentation for more information about releases for the latest node components.
-The full set of components that have releases are:
-
-- `chain-mon`
-- `ci-builder`
-- `ci-builder`
-- `indexer`
-- `op-batcher`
-- `op-contracts`
-- `op-challenger`
-- `op-heartbeat`
-- `op-node`
-- `op-proposer`
-- `op-ufm`
-- `proxyd`
-
-All other components and packages should be considered development components only and do not have releases.
-
-### Development branch
-
-The primary development branch is [`develop`](https://github.com/ethereum-optimism/optimism/tree/develop/).
-`develop` contains the most up-to-date software that remains backwards compatible with the latest experimental [network deployments](https://community.optimism.io/docs/useful-tools/networks/).
-If you're making a backwards compatible change, please direct your pull request towards `develop`.
-
-**Changes to contracts within `packages/contracts-bedrock/src` are usually NOT considered backwards compatible.**
-Some exceptions to this rule exist for cases in which we absolutely must deploy some new contract after a tag has already been fully deployed.
-If you're changing or adding a contract and you're unsure about which branch to make a PR into, default to using a feature branch.
-Feature branches are typically used when there are conflicts between 2 projects touching the same code, to avoid conflicts from merging both into `develop`.
-
-## License
-
-All other files within this repository are licensed under the [MIT License](https://github.com/ethereum-optimism/optimism/blob/master/LICENSE) unless stated otherwise.

--- a/packages/tokamak/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
+++ b/packages/tokamak/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
@@ -38,6 +38,8 @@ contract L1CrossDomainMessenger is CrossDomainMessenger, OnApprove, ISemver {
     /// @custom:semver 2.4.0
     string public constant version = "2.4.0";
 
+    event GasLog(uint256 gasLeft);
+
     /// @notice Constructs the L1CrossDomainMessenger contract.
     constructor() CrossDomainMessenger() {
         initialize({
@@ -231,6 +233,8 @@ contract L1CrossDomainMessenger is CrossDomainMessenger, OnApprove, ISemver {
         payable
         override
     {
+        emit GasLog(gasleft());
+
         require(paused() == false, "L1 CrossDomainMessenger: paused");
         require(msg.value == 0, "CrossDomainMessenger: value must be zero");
 
@@ -268,6 +272,8 @@ contract L1CrossDomainMessenger is CrossDomainMessenger, OnApprove, ISemver {
 
         require(successfulMessages[versionedHash] == false, "CrossDomainMessenger: message has already been relayed");
 
+        emit GasLog(gasleft());
+
         // If there is not enough gas left to perform the external call and finish the execution,
         // return early and assign the message to the failedMessages mapping.
         // We are asserting that we have enough gas to:
@@ -295,13 +301,21 @@ contract L1CrossDomainMessenger is CrossDomainMessenger, OnApprove, ISemver {
             return;
         }
 
+        emit GasLog(gasleft());
+
+
         xDomainMsgSender = _sender;
         // _target must not be address(0). otherwise, this transaction could be reverted
         if (_value != 0 && _target != address(0)) {
             IERC20(_nativeTokenAddress).approve(_target, _value);
         }
+        emit GasLog(gasleft());
+
         // _target is expected to perform a transferFrom to collect token
         bool success = SafeCall.call(_target, gasleft() - RELAY_RESERVED_GAS, 0, _message);
+
+        emit GasLog(gasleft());
+
         if (_value != 0 && _target != address(0)) {
             IERC20(_nativeTokenAddress).approve(_target, 0);
         }
@@ -326,5 +340,6 @@ contract L1CrossDomainMessenger is CrossDomainMessenger, OnApprove, ISemver {
                 revert("CrossDomainMessenger: failed to relay message");
             }
         }
+        emit GasLog(gasleft());
     }
 }


### PR DESCRIPTION
THis PR is for analyzing gas cost in L1CrossDomainMessenger.relayMessage. It will be closed

Testing method:
- Run Devnet
- Unittest

What we want here is the call L1CrossDomainMessenger.relayMessage from OptimismPortal cannot be reverted.
If the call reverts, token will be locked in OptimismPortal and relayMessage cannot be successful. It could happen if L1CrossDomainMessenger.relayMessage run out-of-gas in its context. By this test, we will check how many gas is used for relayMessage()

The tests show that relayMessage only takes from than 100K ~ 140K gas and gas cost after the external call is executed is ~25K gas (RELAY_RESERVED_GAS = 40_000). So we don't have any issues relates to gas here because the because the total gas provided by OptimismPortal for thí context is  ~300K gas

However, RELAY_GAS_CHECK_BUFFER needs to be increased to 35_000 from 5000 because the gas cost after SafeCall.hasMinGas until the external call is increasing by ~27K gas (The call still succeeds because the total gas provided by OptimismPortal ~300K gas)

Let explain why there is not much extra gas in relayMessage? Because Thanos has used gas optimization techniques, such as resetting storage values to their original state, or clear the storage values or leverage warm accessed objects.

For example the code below:

```
    if (_value != 0 && _target != address(0)) {
        IERC20(_nativeTokenAddress).approve(_target, 0);
    }
```
- The contract L2 native token is called again so it is a warm access.
- And we try to clear the approval storage. If the storage value is 0 already, the gas cost is low.

We can visit the doc that explain opcode SSTORE at https://ethereum.org/en/developers/docs/evm/opcodes/
And: https://github.com/wolflo/evm-opcodes/blob/main/gas.md#a7-sstore

Thank you very much!