### PR TITLE
Or 1861 automatic update of action version using dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,5 @@ updates:
     commit-message:
       prefix: "dependabot(actions): "
     reviewers:
-      # - '@tokamak-network/layer2-core'
-      - '@xxeonge'
-    target-branch: "OR-1861-Automatic-update-of-action-version-using-dependabot" #"main"
+      - '@tokamak-network/layer2-core'
+    target-branch: "main"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      time: "13:00"
+      timezone: "Asia/Singapore"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "dependabot(actions): "
+    reviewers:
+      # - '@tokamak-network/layer2-core'
+      - '@xxeonge'
+    target-branch: "OR-1861-Automatic-update-of-action-version-using-dependabot" #"main"


### PR DESCRIPTION
Hello! 

We can use dependabot to check GitHub-action periodically and update it automatically.
This helps ensure that checks don't fail due to working version dismatch.

Thank you so much! ◡̎ 