### PR TITLE
fix(cmd): devnet test failed because putting wrong params in the Hardhat tasks

### DIFF
--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -456,12 +456,10 @@ def devnet_test(paths):
     # And do not use devnet system addresses, to avoid breaking fee-estimation or nonce values.
     run_commands([
         CommandPreset('erc20-test',
-          ['npx', 'hardhat',  'deposit-erc20', '--network',  'devnetL1',
-           '--l1-contracts-json-path', paths.addresses_json_path, '--signer-index', '14'],
+          ['npx', 'hardhat',  'deposit-erc20', '--network',  'devnetL1'],
           cwd=paths.sdk_dir, timeout=8*60),
         CommandPreset('eth-test',
-          ['npx', 'hardhat',  'deposit-eth', '--network',  'devnetL1',
-           '--l1-contracts-json-path', paths.addresses_json_path, '--signer-index', '15'],
+          ['npx', 'hardhat',  'deposit-eth', '--network',  'devnetL1'],
           cwd=paths.sdk_dir, timeout=8*60)
     ], max_workers=1)
 


### PR DESCRIPTION
When running `make devnet-test`, it will fail because we put the wrong params in Hardhat tasks

Refer: https://tokamak-network.slack.com/archives/C07HZARMSTD/p1728369793151639