### PR TITLE
fix: remove calling paused in L2StandardBridge

### DIFF
--- a/packages/tokamak/contracts-bedrock/src/L2/L2StandardBridge.sol
+++ b/packages/tokamak/contracts-bedrock/src/L2/L2StandardBridge.sol
@@ -101,7 +101,6 @@ contract L2StandardBridge is StandardBridge, ISemver {
         override
         onlyOtherBridge
     {
-        require(paused() == false, "StandardBridge: paused");
         require(msg.value == _amount, "StandardBridge: amount sent does not match amount required");
         require(_to != address(this), "StandardBridge: cannot send to self");
         require(_to != address(messenger), "StandardBridge: cannot send to messenger");
@@ -132,7 +131,6 @@ contract L2StandardBridge is StandardBridge, ISemver {
         override
         onlyOtherBridge
     {
-        require(paused() == false, "StandardBridge: paused");
         OptimismMintableERC20(Predeploys.ETH).mint(_to, _amount);
         _emitETHBridgeFinalized(_from, _to, _amount, _extraData);
     }


### PR DESCRIPTION
I removed require statement for checking whether this contract is paused in L2StandardBridge. 
* `paused()` function in L2StandardBridge always returns `false`. It means an unnecessary require statement was used. 
* This issue is reported from https://github.com/tokamak-network/tokamak-thanos/issues/271.
