### PR TITLE
feat(sdk): release v0.0.10

### DIFF
--- a/packages/tokamak/sdk/package.json
+++ b/packages/tokamak/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokamak-network/thanos-sdk",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Tools for working with Thanos",
   "main": "dist/index",
   "types": "dist/index",


### PR DESCRIPTION
I pump the version of SDK to 0.0.10. I made a mistake in creating a tag `0.0.9` last two months so the version of SDK right now is 0.0.9