### PR TITLE
feat(contracts-bedrock): release v0.0.5

### DIFF
--- a/packages/tokamak/contracts-bedrock/package.json
+++ b/packages/tokamak/contracts-bedrock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokamak-network/thanos-contracts",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Contracts for Optimism Specs",
   "license": "MIT",
   "files": [


### PR DESCRIPTION
The new version of SDK is using the latest version of contracts, so we should pump `@tokamak-network/contracts-bedrock` to a new version