### PR TITLE
Or 1935 op challenger and op proposer metrics add prometheus alert rules

### DIFF
--- a/op-proposer/metrics/metrics.go
+++ b/op-proposer/metrics/metrics.go
@@ -35,7 +35,7 @@ type Metricer interface {
 
 	RecordL2BlocksProposed(l2ref eth.L2BlockRef)
 
-	RecordValidProposer(account common.Address, isValid bool)
+	RecordThanosProposer(account common.Address, isThanos bool)
 }
 
 type Metrics struct {
@@ -50,7 +50,7 @@ type Metrics struct {
 	info prometheus.GaugeVec
 	up   prometheus.Gauge
 
-	validProposer prometheus.GaugeVec
+	thanosProposer prometheus.GaugeVec
 }
 
 var _ Metricer = (*Metrics)(nil)
@@ -85,10 +85,10 @@ func NewMetrics(procName string) *Metrics {
 			Name:      "up",
 			Help:      "1 if the op-proposer has finished starting up",
 		}),
-		validProposer: *factory.NewGaugeVec(prometheus.GaugeOpts{
+		thanosProposer: *factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: ns,
-			Name:      "default_proposer_valid",
-			Help:      "Indicates whether the proposer is valid (1) or invalid (0)",
+			Name:      "default_proposer_thanos",
+			Help:      "Indicates whether the proposer is thanos (1) or not (0)",
 		}, []string{
 			"account",
 		}),
@@ -128,13 +128,13 @@ func (m *Metrics) Document() []opmetrics.DocumentedMetric {
 	return m.factory.Document()
 }
 
-func (m *Metrics) RecordValidProposer(account common.Address, isValid bool) {
-	validProposerAddr := common.HexToAddress("0xf8873b3Fac779A00E54FF08424B14a9327e81cFa")
-	validValue := float64(0)
+func (m *Metrics) RecordThanosProposer(account common.Address, isThanos bool) {
+	thanosProposerAddr := common.HexToAddress("0xf8873b3Fac779A00E54FF08424B14a9327e81cFa")
+	thanosValue := float64(0)
 
-	if account == validProposerAddr && isValid {
-		validValue = 1
+	if account == thanosProposerAddr && isThanos {
+		thanosValue = 1
 	}
 
-	m.validProposer.WithLabelValues(account.Hex()).Set(validValue)
+	m.thanosProposer.WithLabelValues(account.Hex()).Set(thanosValue)
 }

--- a/op-proposer/metrics/noop.go
+++ b/op-proposer/metrics/noop.go
@@ -29,4 +29,4 @@ func (*noopMetrics) StartBalanceMetrics(log.Logger, *ethclient.Client, common.Ad
 	return nil
 }
 
-func (*noopMetrics) RecordValidProposer(account common.Address, isValid bool) {}
+func (*noopMetrics) RecordThanosProposer(account common.Address, isThanos bool) {}

--- a/op-proposer/metrics/noop.go
+++ b/op-proposer/metrics/noop.go
@@ -28,3 +28,5 @@ func (*noopMetrics) RecordL2BlocksProposed(l2ref eth.L2BlockRef) {}
 func (*noopMetrics) StartBalanceMetrics(log.Logger, *ethclient.Client, common.Address) io.Closer {
 	return nil
 }
+
+func (*noopMetrics) RecordValidProposer(account common.Address, isValid bool) {}


### PR DESCRIPTION
updated the metrics to enable detection and monitoring by comparing the op-proposer account in the Fault Proof System (FPS) with external proposer accounts.

Thank you!