### PR TITLE
feat(contracts-bedrock): release v0.0.6

### DIFF
--- a/packages/tokamak/contracts-bedrock/package.json
+++ b/packages/tokamak/contracts-bedrock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokamak-network/thanos-contracts",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Contracts for Optimism Specs",
   "license": "MIT",
   "files": [


### PR DESCRIPTION
Release a new version of the Thanos contract to support changing the L1USDC bridge.