### PR TITLE
[OR-1983] Upgrade FaultDisputeGame: reduce ClockDuration to 120s

### DIFF
--- a/packages/tokamak/contracts-bedrock/deploy-config/thanos-stack-sepolia.json
+++ b/packages/tokamak/contracts-bedrock/deploy-config/thanos-stack-sepolia.json
@@ -52,7 +52,7 @@
   "faultGameAbsolutePrestate": "0x03ab262ce124af0d5d328e09bf886a2b272fe960138115ad8b94fdc3034e3155",
   "faultGameMaxDepth": 50,
   "faultGameClockExtension": 0,
-  "faultGameMaxClockDuration": 1200,
+  "faultGameMaxClockDuration": 120,
   "faultGameGenesisBlock": 0,
   "faultGameGenesisOutputRoot": "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
   "faultGameSplitDepth": 14,


### PR DESCRIPTION
I have completed the upgrade of the FaultDisputeGame contract.
However, instead of the proposed 6 seconds, I have changed it to 120 seconds.

Below is part of the constructor for the FaultDisputeGame contract.
```solidity
uint256 splitDepthExtension = uint256(_clockExtension.raw()) * 2;
uint256 maxGameDepthExtension = uint256(_clockExtension.raw()) + uint256(_vm.oracle().challengePeriod());
uint256 maxClockExtension = Math.max(splitDepthExtension, maxGameDepthExtension);

// The maximum clock extension must fit into a uint64.
if (maxClockExtension > type(uint64).max) revert InvalidClockExtension();

// The maximum clock extension may not be greater than the maximum clock duration.
if (uint64(maxClockExtension) > _maxClockDuration.raw()) revert InvalidClockExtension();
```

Based on the calculation above, maxClockExtension is set to 120, so _maxClockDuration cannot be set to a value smaller than 120 seconds.
As a result, it has been set to 120 seconds.

Currently, the FaultDisputeGame resolves within 2 minutes. Thank you.