### PR TITLE
Add seignorage receiver in SystemConfig

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -65,6 +65,8 @@ type DeployConfig struct {
 	NativeTokenSymbol string `json:"nativeTokenSymbol"`
 	// L1Token is the L1's address of the L2 chain's native token.
 	NativeTokenAddress common.Address `json:"nativeTokenAddress"`
+	// SeigniorageReceiver is the receiver of seigniorage.
+	SeigniorageReceiver common.Address `json:"seigniorageReceiver"`
 	// L1ChainID is the chain ID of the L1 chain.
 	L1ChainID uint64 `json:"l1ChainID"`
 	// L2ChainID is the chain ID of the L2 chain.
@@ -383,6 +385,9 @@ func (d *DeployConfig) Check() error {
 	}
 	if d.L2ChainID == 0 {
 		return fmt.Errorf("%w: L2ChainID cannot be 0", ErrInvalidDeployConfig)
+	}
+	if d.SeigniorageReceiver == (common.Address{}) {
+		return fmt.Errorf("%w: SeigniorageReceiver cannot be address(0)", ErrInvalidDeployConfig)
 	}
 	if d.L2BlockTime == 0 {
 		return fmt.Errorf("%w: L2BlockTime cannot be 0", ErrInvalidDeployConfig)

--- a/op-chain-ops/genesis/testdata/test-deploy-config-full.json
+++ b/op-chain-ops/genesis/testdata/test-deploy-config-full.json
@@ -153,5 +153,6 @@
   "daChallengeProxy": "0x0000000000000000000000000000000000000000",
   "daChallengeWindow": 0,
   "daResolveWindow": 0,
-  "daResolverRefundPercentage": 0
+  "daResolverRefundPercentage": 0,
+  "seigniorageReceiver": "0x0000000000000000000000000000000000000000"
 }

--- a/packages/tokamak/contracts-bedrock/deploy-config/devnetL1-template.json
+++ b/packages/tokamak/contracts-bedrock/deploy-config/devnetL1-template.json
@@ -5,6 +5,7 @@
   "nativeTokenName": "Tokamak Network Token",
   "nativeTokenSymbol": "TON",
   "nativeTokenAddress": "0x75fE809aE1C4A66c27a0239F147d0cc5710a104A",
+  "seigniorageReceiver": "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720",
   "setPrecompileBalances": false,
   "maxSequencerDrift": 300,
   "sequencerWindowSize": 200,

--- a/packages/tokamak/contracts-bedrock/deploy-config/hardhat.json
+++ b/packages/tokamak/contracts-bedrock/deploy-config/hardhat.json
@@ -67,5 +67,6 @@
   "nativeTokenSymbol": "TON",
   "nativeTokenAddress": "0xC7844340d14deAedfDD2f2dD9360c336661b2F0A",
   "l1UsdcAddr": "0x2910E325cf29dd912E3476B61ef12F49cb931096",
-  "devnet": true
+  "devnet": true,
+  "seigniorageReceiver": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc"
 }

--- a/packages/tokamak/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/tokamak/contracts-bedrock/scripts/Deploy.s.sol
@@ -1130,7 +1130,6 @@ contract Deploy is Deployer {
         address seigniorageReceiver = cfg.seigniorageReceiver();
         console.log(" [Check ]seigniorageReceiver", seigniorageReceiver);
 
-
         _upgradeAndCallViaSafe({
             _proxy: payable(systemConfigProxy),
             _implementation: systemConfig,

--- a/packages/tokamak/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/tokamak/contracts-bedrock/scripts/Deploy.s.sol
@@ -1127,6 +1127,9 @@ contract Deploy is Deployer {
             l2NativeTokenAddress = address(token);
         }
         console.log(" [Check ]l2NativeTokenAddress", l2NativeTokenAddress);
+        address seigniorageReceiver = cfg.seigniorageReceiver();
+        console.log(" [Check ]seigniorageReceiver", seigniorageReceiver);
+
 
         _upgradeAndCallViaSafe({
             _proxy: payable(systemConfigProxy),
@@ -1150,7 +1153,8 @@ contract Deploy is Deployer {
                         optimismPortal: mustGetAddress("OptimismPortalProxy"),
                         optimismMintableERC20Factory: mustGetAddress("OptimismMintableERC20FactoryProxy"),
                         gasPayingToken: customGasTokenAddress,
-                        nativeTokenAddress: l2NativeTokenAddress
+                        nativeTokenAddress: l2NativeTokenAddress,
+                        seigniorageReceiver: seigniorageReceiver
                     })
                 )
             )

--- a/packages/tokamak/contracts-bedrock/scripts/DeployConfig.s.sol
+++ b/packages/tokamak/contracts-bedrock/scripts/DeployConfig.s.sol
@@ -25,6 +25,7 @@ contract DeployConfig is Script {
     address public finalSystemOwner;
     address public superchainConfigGuardian;
     address public nativeTokenAddress;
+    address public seigniorageReceiver;
     uint256 public l1ChainID;
     uint256 public l2ChainID;
     uint256 public l2BlockTime;
@@ -106,6 +107,7 @@ contract DeployConfig is Script {
         finalSystemOwner = stdJson.readAddress(_json, "$.finalSystemOwner");
         superchainConfigGuardian = stdJson.readAddress(_json, "$.superchainConfigGuardian");
         nativeTokenAddress = stdJson.readAddress(_json, "$.nativeTokenAddress");
+        seigniorageReceiver = stdJson.readAddress(_json, "$.seigniorageReceiver");
         l1ChainID = stdJson.readUint(_json, "$.l1ChainID");
         l2ChainID = stdJson.readUint(_json, "$.l2ChainID");
         l2BlockTime = stdJson.readUint(_json, "$.l2BlockTime");

--- a/packages/tokamak/contracts-bedrock/scripts/getting-started/config.sh
+++ b/packages/tokamak/contracts-bedrock/scripts/getting-started/config.sh
@@ -42,6 +42,8 @@ config=$(cat << EOL
   "nativeTokenSymbol": "CHANGE_ME",
   "nativeTokenAddress": "CHANGE_ME",
 
+  "seigniorageReceiver": "$GS_ADMIN_ADDRESS",
+
   "maxSequencerDrift": 600,
   "sequencerWindowSize": 3600,
   "channelTimeout": 300,

--- a/packages/tokamak/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/tokamak/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -543,8 +543,7 @@ contract OptimismPortal2 is Initializable, ResourceMetering, OnApprove, ISemver 
         require(_data.length <= 120_000, "OptimismPortal: data too large");
 
         // Transform the from-address to its alias if the caller is a contract.
-        address from =
-            ((_sender != tx.origin)) ? AddressAliasHelper.applyL1ToL2Alias(_sender) : _sender;
+        address from = ((_sender != tx.origin)) ? AddressAliasHelper.applyL1ToL2Alias(_sender) : _sender;
 
         // Compute the opaque data that will be emitted as part of the TransactionDeposited event.
         // We use opaque data so that we can update the TransactionDeposited event in the future

--- a/packages/tokamak/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/tokamak/contracts-bedrock/src/L1/SystemConfig.sol
@@ -40,6 +40,7 @@ contract SystemConfig is OwnableUpgradeable, ISemver, IGasToken {
         address optimismMintableERC20Factory;
         address gasPayingToken;
         address nativeTokenAddress;
+        address seigniorageReceiver;
     }
 
     /// @notice Version identifier, used for upgrades.
@@ -81,6 +82,9 @@ contract SystemConfig is OwnableUpgradeable, ISemver, IGasToken {
     /// @notice Storage slot that the native token address is stored at.
     bytes32 public constant NATIVE_TOKEN_ADDRESS_SLOT =
         bytes32(uint256(keccak256("systemconfig.nativetokenaddress")) - 1);
+
+    // @notice Storage slot that the seigniorage receiver address is stored at.
+    bytes32 public constant SEIGNIORAGE_RECEIVER_SLOT = bytes32(uint256(keccak256("systemconfig.seignioragereceiver")) - 1);
 
     /// @notice Storage slot for the DisputeGameFactory address.
     bytes32 public constant DISPUTE_GAME_FACTORY_SLOT =
@@ -165,7 +169,8 @@ contract SystemConfig is OwnableUpgradeable, ISemver, IGasToken {
                 optimismPortal: address(0),
                 optimismMintableERC20Factory: address(0),
                 gasPayingToken: address(0),
-                nativeTokenAddress: address(0)
+                nativeTokenAddress: address(0),
+                seigniorageReceiver: address(0)
             })
         });
     }
@@ -213,6 +218,7 @@ contract SystemConfig is OwnableUpgradeable, ISemver, IGasToken {
         Storage.setAddress(OPTIMISM_PORTAL_SLOT, _addresses.optimismPortal);
         Storage.setAddress(OPTIMISM_MINTABLE_ERC20_FACTORY_SLOT, _addresses.optimismMintableERC20Factory);
         Storage.setAddress(NATIVE_TOKEN_ADDRESS_SLOT, _addresses.nativeTokenAddress);
+        Storage.setAddress(SEIGNIORAGE_RECEIVER_SLOT, _addresses.seigniorageReceiver);
 
         _setStartBlock();
         // _setGasPayingToken(_addresses.gasPayingToken);
@@ -290,6 +296,11 @@ contract SystemConfig is OwnableUpgradeable, ISemver, IGasToken {
     /// @notice Getter for the native token address.
     function nativeTokenAddress() external view returns (address addr_) {
         addr_ = Storage.getAddress(NATIVE_TOKEN_ADDRESS_SLOT);
+    }
+
+    /// @notice Getter for the seigniorage receiver address.
+    function seigniorageReceiver() external view returns (address addr_) {
+        addr_ = Storage.getAddress(SEIGNIORAGE_RECEIVER_SLOT);
     }
 
     /// @notice Getter for the gas paying asset address.

--- a/packages/tokamak/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/tokamak/contracts-bedrock/src/L1/SystemConfig.sol
@@ -84,7 +84,8 @@ contract SystemConfig is OwnableUpgradeable, ISemver, IGasToken {
         bytes32(uint256(keccak256("systemconfig.nativetokenaddress")) - 1);
 
     // @notice Storage slot that the seigniorage receiver address is stored at.
-    bytes32 public constant SEIGNIORAGE_RECEIVER_SLOT = bytes32(uint256(keccak256("systemconfig.seignioragereceiver")) - 1);
+    bytes32 public constant SEIGNIORAGE_RECEIVER_SLOT =
+        bytes32(uint256(keccak256("systemconfig.seignioragereceiver")) - 1);
 
     /// @notice Storage slot for the DisputeGameFactory address.
     bytes32 public constant DISPUTE_GAME_FACTORY_SLOT =

--- a/packages/tokamak/contracts-bedrock/src/L2/L1BlockInterop.sol
+++ b/packages/tokamak/contracts-bedrock/src/L2/L1BlockInterop.sol
@@ -1,4 +1,3 @@
-
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 

--- a/packages/tokamak/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
+++ b/packages/tokamak/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
@@ -17,7 +17,6 @@ import { Predeploys } from "src/libraries/Predeploys.sol";
 ///         L2 on the L2 side. Users are generally encouraged to use this contract instead of lower
 ///         level message passing contracts.
 contract L2CrossDomainMessenger is CrossDomainMessenger, ISemver {
-
     /// @custom:semver 2.1.0
     string public constant version = "2.1.0";
 

--- a/packages/tokamak/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/tokamak/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -74,6 +74,7 @@ contract SystemConfig_Initialize_Test is SystemConfig_Init {
         assertEq(address(impl.disputeGameFactory()), address(0));
         assertEq(address(impl.optimismPortal()), address(0));
         assertEq(address(impl.optimismMintableERC20Factory()), address(0));
+        assertEq(address(impl.seigniorageReceiver()), address(0));
         // Check gas paying token
         (address token, uint8 decimals) = impl.gasPayingToken();
         assertEq(token, Constants.ETHER);
@@ -110,6 +111,7 @@ contract SystemConfig_Initialize_Test is SystemConfig_Init {
         assertEq(address(systemConfig.disputeGameFactory()), address(disputeGameFactory));
         assertEq(address(systemConfig.optimismPortal()), address(optimismPortal));
         assertEq(address(systemConfig.optimismMintableERC20Factory()), address(optimismMintableERC20Factory));
+        assertEq(address(systemConfig.seigniorageReceiver()), deploy.cfg().seigniorageReceiver());
         // Check gas paying token
         (address token, uint8 decimals) = systemConfig.gasPayingToken();
         assertEq(token, Constants.ETHER);
@@ -146,7 +148,8 @@ contract SystemConfig_Initialize_TestFail is SystemConfig_Initialize_Test {
                 optimismPortal: address(0),
                 optimismMintableERC20Factory: address(0),
                 nativeTokenAddress: address(0),
-                gasPayingToken: Constants.ETHER
+                gasPayingToken: Constants.ETHER,
+                seigniorageReceiver: address(0)
             })
         });
     }
@@ -177,6 +180,7 @@ contract SystemConfig_Initialize_TestFail is SystemConfig_Initialize_Test {
                 optimismPortal: address(0),
                 optimismMintableERC20Factory: address(0),
                 nativeTokenAddress: address(0),
+                seigniorageReceiver: address(0),
                 gasPayingToken: Constants.ETHER
             })
         });
@@ -209,6 +213,7 @@ contract SystemConfig_Initialize_TestFail is SystemConfig_Initialize_Test {
                 optimismPortal: address(0),
                 optimismMintableERC20Factory: address(0),
                 nativeTokenAddress: address(0),
+                seigniorageReceiver: address(0),
                 gasPayingToken: Constants.ETHER
             })
         });
@@ -305,6 +310,7 @@ contract SystemConfig_Init_ResourceConfig is SystemConfig_Init {
                 optimismPortal: address(0),
                 optimismMintableERC20Factory: address(0),
                 nativeTokenAddress: address(0),
+                seigniorageReceiver: address(0),
                 gasPayingToken: address(0)
             })
         });

--- a/packages/tokamak/contracts-bedrock/test/L1/SystemConfigInterop.t.sol
+++ b/packages/tokamak/contracts-bedrock/test/L1/SystemConfigInterop.t.sol
@@ -88,6 +88,7 @@ contract SystemConfigInterop_Test is CommonTest {
                 optimismPortal: address(optimismPortal),
                 optimismMintableERC20Factory: address(0),
                 nativeTokenAddress: address(0),
+                seigniorageReceiver: address(0),
                 gasPayingToken: _token
             })
         });

--- a/packages/tokamak/contracts-bedrock/test/invariants/SystemConfig.t.sol
+++ b/packages/tokamak/contracts-bedrock/test/invariants/SystemConfig.t.sol
@@ -35,6 +35,7 @@ contract SystemConfig_GasLimitBoundaries_Invariant is Test {
                         optimismPortal: address(0),
                         optimismMintableERC20Factory: address(0),
                         nativeTokenAddress: address(0),
+                        seigniorageReceiver: address(0),
                         gasPayingToken: Constants.ETHER
                     })
                 )

--- a/packages/tokamak/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/tokamak/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -187,6 +187,7 @@ contract Initializer_Test is Bridge_Initializer {
                             optimismPortal: address(0),
                             optimismMintableERC20Factory: address(0),
                             nativeTokenAddress: address(0),
+                            seigniorageReceiver: address(0),
                             gasPayingToken: Constants.ETHER
                         })
                     )
@@ -224,6 +225,7 @@ contract Initializer_Test is Bridge_Initializer {
                             optimismPortal: address(0),
                             optimismMintableERC20Factory: address(0),
                             nativeTokenAddress: address(0),
+                            seigniorageReceiver: address(0),
                             gasPayingToken: Constants.ETHER
                         })
                     )


### PR DESCRIPTION
### Description
Added the address to receive seigniorage for TON Staking v2.5 integration in Q1
* Variable: `SystemConfig.seigniorageReceiver()`

### Tasks
- [x]  update `SystemConfig`
- [x]  update deploy script
- [x]  update unit test code
- [x]  run unit test for `SystemConfig`

```bash
pnpm build:go-ffi

forge test --match-path ./test/L1/SystemConfig.t.sol
```

- [x]  add params `seigniorageReceiver` in deploy config file
- [x]  update generation script for deploy config file
- [x]  test to run devnet

### References
https://tokamak-network.github.io/papers/tokamak-cryptoeconomics-en.pdf
https://www.notion.so/tokamak/How-to-make-the-L2-candidate-of-simple-staking-for-TRH-L2-17dd96a400a38095a0b4db30ff08771b?pvs=4