### PR TITLE
update hardhat task: set-safe-wallet

### DIFF
--- a/packages/tokamak/sdk/tasks/set-safe-for-dao.ts
+++ b/packages/tokamak/sdk/tasks/set-safe-for-dao.ts
@@ -1,5 +1,5 @@
 import { ethers } from 'ethers'
-import { task, types } from 'hardhat/config'
+import { task } from 'hardhat/config'
 import { executeContractCallWithSigners } from '@tokamak-network/thanos-contracts/lib/safe-contracts/src/utils/execution'
 
 import { getDAOMembers } from '../src/utils/owners'
@@ -18,81 +18,116 @@ export const addOwnerAndVerify = async (
   threshold: number,
   signers: ethers.Signer[]
 ): Promise<void> => {
-  // Execute addOwnerWithThreshold
-  const tx = await executeContractCallWithSigners(
-    safeContract,
-    safeContract,
-    'addOwnerWithThreshold',
-    [owner, threshold],
-    signers
-  )
-  console.log(`Tx Hash for adding owner ${owner}:`, tx.hash)
-  await tx.wait()
+  try {
+    // Execute addOwnerWithThreshold
+    const tx = await executeContractCallWithSigners(
+      safeContract,
+      safeContract,
+      'addOwnerWithThreshold',
+      [owner, threshold],
+      signers
+    )
+    console.log(`Tx Hash for adding owner ${owner}:`, tx.hash)
 
-  // Get Safe owner
-  const safeOwners = await safeContract.getOwners()
-  console.log(`Safe owners after adding owner ${owner}:`, safeOwners)
-  if (safeOwners.includes(owner)) {
+    // Wait for transaction and check status
+    const receipt = await tx.wait()
+    if (receipt.status !== 1) {
+      throw new Error(
+        `Transaction failed for adding owner ${owner}. Tx Hash: ${tx.hash}`
+      )
+    }
+
+    // Get Safe owners and verify
+    const safeOwners = await safeContract.getOwners()
+    console.log(`Safe owners after adding owner ${owner}:`, safeOwners)
+    if (!safeOwners.includes(owner)) {
+      throw new Error(
+        `Verification failed: Owner ${owner} was not added to the safe.`
+      )
+    }
     console.log(`Successfully added owner: ${owner}`)
-  } else {
-    console.log(`Failed to add owner: ${owner}`)
+  } catch (error) {
+    console.error(`Error adding owner ${owner}:`, error)
+    throw error // re-throw the error for handling to upper level
   }
 }
 
 // Task
-task('set-safe-wallet', 'Set Safe Wallet for the TokamakDAO')
-  .addParam('rpc', 'L1 RPC endpoint', '', types.string)
-  .addParam('chainid', 'L1 chain id', '', types.int)
-  .addParam('privatekey', 'Admin Private key', '', types.string)
-  .addParam('address', 'Gnosis Safe contract address', '', types.string)
-  .setAction(async (args) => {
-    const l1Provider = new ethers.providers.StaticJsonRpcProvider(args.rpc)
-
-    // Create the signer
-    // TODO: Get the Admin's private key from the seed phrase (user's input)
-    const ownerAPrivateKey = args.privatekey
-    const signer = new ethers.Wallet(ownerAPrivateKey, l1Provider)
-
-    // Get predefined owners
-    const owners = getDAOMembers(args.chainid)
-
-    // ABIs of Gnosis Safe
-    const gnosisSafeAbi = [
-      'function getThreshold() view returns (uint256)',
-      'function addOwnerWithThreshold(address owner, uint256 _threshold) external',
-      'function changeThreshold(uint256 _threshold) external',
-      'function execTransaction(address to, uint256 value, bytes calldata data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, bytes calldata signatures) external returns (bool success)',
-      'function nonce() view returns (uint256)',
-      'function getOwners() view returns (address[])',
-    ]
-
-    // Create contract instance
-    const gnosisSafeContract = new ethers.Contract(
-      args.address,
-      gnosisSafeAbi,
-      signer
-    )
-    console.log('Gnosis Safe Contract:', gnosisSafeContract.address)
-
-    // Execute
+task('set-safe-wallet', 'Set Safe Wallet for the Tokamak DAO').setAction(
+  async () => {
     try {
-      // Add 2 owners to Safe
-      await addOwnerAndVerify(gnosisSafeContract, owners[0], 1, [signer])
-      await addOwnerAndVerify(gnosisSafeContract, owners[1], 1, [signer])
+      // Verify ENVs
+      const l1Url = process.env.L1_URL
+      const privateKey = process.env.PRIVATE_KEY
+      const safeWalletAddress = process.env.SAFE_WALLET_ADDRESS
+
+      if (!l1Url || !privateKey || !safeWalletAddress) {
+        throw new Error(
+          'Missing required environment variables: L1_URL, PRIVATE_KEY, SAFE_WALLET_ADDRESS'
+        )
+      }
+
+      const l1Provider = new ethers.providers.StaticJsonRpcProvider(l1Url)
+      const network = await l1Provider.getNetwork()
+      console.log('L1 Chain ID:', network.chainId)
+
+      // Create the signer
+      const signer = new ethers.Wallet(privateKey, l1Provider)
+
+      // Get the desigated owners depending network
+      const designatedOwners = getDAOMembers(network.chainId)
+      if (!designatedOwners || designatedOwners.length < 2) {
+        throw new Error(
+          'Insufficient DAO members returned for designated owners'
+        )
+      }
+
+      // ABIs of Gnosis Safe
+      const gnosisSafeAbi = [
+        'function getThreshold() view returns (uint256)',
+        'function addOwnerWithThreshold(address owner, uint256 _threshold) external',
+        'function changeThreshold(uint256 _threshold) external',
+        'function execTransaction(address to, uint256 value, bytes calldata data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, bytes calldata signatures) external returns (bool success)',
+        'function nonce() view returns (uint256)',
+        'function getOwners() view returns (address[])',
+      ]
+
+      // Create Gnosis safe contract instance
+      const gnosisSafeContract = new ethers.Contract(
+        safeWalletAddress,
+        gnosisSafeAbi,
+        signer
+      )
+      console.log('Gnosis Safe Contract:', gnosisSafeContract.address)
+
+      // Execute: Add owners to Safe
+      await addOwnerAndVerify(gnosisSafeContract, designatedOwners[0], 1, [
+        signer,
+      ])
+      await addOwnerAndVerify(gnosisSafeContract, designatedOwners[1], 1, [
+        signer,
+      ])
 
       // Change threshold to 3
-      const tx3 = await executeContractCallWithSigners(
+      const txChangeThreshold = await executeContractCallWithSigners(
         gnosisSafeContract,
         gnosisSafeContract,
         'changeThreshold',
         [3],
         [signer]
       )
-      console.log('Tx 3 Hash:', tx3.hash)
-      await tx3.wait()
+      console.log('Tx Hash for changing threshold:', txChangeThreshold.hash)
+      const receiptChangeThreshold = await txChangeThreshold.wait()
+      if (receiptChangeThreshold.status !== 1) {
+        throw new Error(
+          `Threshold change transaction failed. Tx Hash: ${txChangeThreshold.hash}`
+        )
+      }
       const newSafeThreshold = await gnosisSafeContract.getThreshold()
       console.log('New threshold:', String(newSafeThreshold))
     } catch (error) {
       console.error('Got the error running Safe contract:', error)
+      process.exit(1) // exit
     }
-  })
+  }
+)


### PR DESCRIPTION
I updated hardhat task: set-safe-wallet
* Use environment variables instead of arguments
* Error handling
* Fix lint

### ENVs (template)
```bash
# private key of safe wallet owner (admin)
export PRIVATE_KEY=
export NATIVE_TOKEN=
export ADDRESS_MANAGER=
export L1_CROSS_DOMAIN_MESSENGER=
export L1_STANDARD_BRIDGE=
export OPTIMISM_PORTAL=
export L2_OUTPUT_ORACLE=
# address of safe wallet
export SAFE_WALLET_ADDRESS=
export L1_URL=
export L2_URL=
```

### Test 
Before:
```bash
npx hardhat set-safe-wallet --rpc ${L1_URL} --chainid ${L1_CHAINID} --privatekey ${ADMIN_PRIVATE_KEY} --address ${SAFE_WALLET_ADDRESS}
```
After:
```bash
npx hardhat set-safe-wallet
```