### PR TITLE
Feat: skip redundant implementation deployment

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -356,6 +356,8 @@ type DeployConfig struct {
 
 	// Devnet is a flag that indicates if the network is devnet on your local
 	Devnet bool `json:"devnet,omitempty"`
+	// IsFirstDeploy is a flag that check if this is first deployment or not
+	IsFirstDeploy bool `json:"isFirstDeploy,omitempty"`
 }
 
 // Copy will deeply copy the DeployConfig. This does a JSON roundtrip to copy

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -356,8 +356,8 @@ type DeployConfig struct {
 
 	// Devnet is a flag that indicates if the network is devnet on your local
 	Devnet bool `json:"devnet,omitempty"`
-	// IsFirstDeploy is a flag that check if this is first deployment or not
-	IsFirstDeploy bool `json:"isFirstDeploy,omitempty"`
+	// ReuseDeployment is a flag that check if we re-use deployment
+	ReuseDeployment bool `json:"reuseDeployment,omitempty"`
 }
 
 // Copy will deeply copy the DeployConfig. This does a JSON roundtrip to copy

--- a/packages/tokamak/contracts-bedrock/deploy-config/devnetL1-template.json
+++ b/packages/tokamak/contracts-bedrock/deploy-config/devnetL1-template.json
@@ -98,5 +98,6 @@
   "pairInitCodeHash": "0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f",
   "poolInitCodeHash": "0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54",
   "universalRouterRewardsDistributor": "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720",
-  "devnet": true
+  "devnet": true,
+  "isFirstDeploy": true
 }

--- a/packages/tokamak/contracts-bedrock/deploy-config/devnetL1-template.json
+++ b/packages/tokamak/contracts-bedrock/deploy-config/devnetL1-template.json
@@ -99,5 +99,5 @@
   "poolInitCodeHash": "0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54",
   "universalRouterRewardsDistributor": "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720",
   "devnet": true,
-  "isFirstDeploy": true
+  "ReuseDeployment": false
 }

--- a/packages/tokamak/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/tokamak/contracts-bedrock/scripts/Deploy.s.sol
@@ -250,7 +250,9 @@ contract Deploy is Deployer {
 
     function verifyImplementationExists(address impl) internal view returns (bool) {
         uint256 codeSize;
-        assembly { codeSize := extcodesize(impl) }
+        assembly {
+            codeSize := extcodesize(impl)
+        }
         return codeSize > 0;
     }
 
@@ -306,7 +308,7 @@ contract Deploy is Deployer {
         // }
         if (cfg.isFirstDeploy() == false) {
             if (chainid == Chains.Sepolia) {
-            jsonDeployment = vm.readFile("./deployments/thanos-stack-sepolia/address.json");
+                jsonDeployment = vm.readFile("./deployments/thanos-stack-sepolia/address.json");
             }
             // for test
             else if (chainid == Chains.LocalDevnet) {
@@ -1129,7 +1131,7 @@ contract Deploy is Deployer {
                     require(delayedWETH != address(0), "DelayedWETH deployment failed");
                     save("DelayedWETH", delayedWETH);
                     console.log("DelayedWETH deployed at %s", delayedWETH);
-                // Import from deployment
+                    // Import from deployment
                 } else {
                     delayedWETH = mustGetAddress("DelayedWETH");
                 }
@@ -1208,7 +1210,11 @@ contract Deploy is Deployer {
                 console.log("Using existing implementation from JSON");
             } else {
                 console.log("Implementation from JSON not found on-chain, deploying new one");
-                anchorStateRegistry = address(new AnchorStateRegistry{ salt: _implSalt() }(DisputeGameFactory(mustGetAddress("DisputeGameFactoryProxy"))));
+                anchorStateRegistry = address(
+                    new AnchorStateRegistry{ salt: _implSalt() }(
+                        DisputeGameFactory(mustGetAddress("DisputeGameFactoryProxy"))
+                    )
+                );
                 require(anchorStateRegistry != address(0), "AnchorStateRegistry deployment failed");
                 save("AnchorStateRegistry", anchorStateRegistry);
                 console.log("AnchorStateRegistry deployed at %s", anchorStateRegistry);
@@ -1265,27 +1271,28 @@ contract Deploy is Deployer {
         }
 
         bytes memory _innerCallData = abi.encodeCall(
-                SystemConfig.initialize,
-                (
-                    cfg.finalSystemOwner(),
-                    cfg.basefeeScalar(),
-                    cfg.blobbasefeeScalar(),
-                    batcherHash,
-                    uint64(cfg.l2GenesisBlockGasLimit()),
-                    cfg.p2pSequencerAddress(),
-                    Constants.DEFAULT_RESOURCE_CONFIG(),
-                    cfg.batchInboxAddress(),
-                    SystemConfig.Addresses({
-                        l1CrossDomainMessenger: mustGetAddress("L1CrossDomainMessengerProxy"),
-                        l1ERC721Bridge: mustGetAddress("L1ERC721BridgeProxy"),
-                        l1StandardBridge: mustGetAddress("L1StandardBridgeProxy"),
-                        disputeGameFactory: mustGetAddress("DisputeGameFactoryProxy"),
-                        optimismPortal: mustGetAddress("OptimismPortalProxy"),
-                        optimismMintableERC20Factory: mustGetAddress("OptimismMintableERC20FactoryProxy"),
-                        gasPayingToken: customGasTokenAddress,
-                        nativeTokenAddress: l2NativeTokenAddress
-                    })
-                ));
+            SystemConfig.initialize,
+            (
+                cfg.finalSystemOwner(),
+                cfg.basefeeScalar(),
+                cfg.blobbasefeeScalar(),
+                batcherHash,
+                uint64(cfg.l2GenesisBlockGasLimit()),
+                cfg.p2pSequencerAddress(),
+                Constants.DEFAULT_RESOURCE_CONFIG(),
+                cfg.batchInboxAddress(),
+                SystemConfig.Addresses({
+                    l1CrossDomainMessenger: mustGetAddress("L1CrossDomainMessengerProxy"),
+                    l1ERC721Bridge: mustGetAddress("L1ERC721BridgeProxy"),
+                    l1StandardBridge: mustGetAddress("L1StandardBridgeProxy"),
+                    disputeGameFactory: mustGetAddress("DisputeGameFactoryProxy"),
+                    optimismPortal: mustGetAddress("OptimismPortalProxy"),
+                    optimismMintableERC20Factory: mustGetAddress("OptimismMintableERC20FactoryProxy"),
+                    gasPayingToken: customGasTokenAddress,
+                    nativeTokenAddress: l2NativeTokenAddress
+                })
+            )
+        );
 
         _upgradeAndCallViaSafe({
             _proxy: payable(systemConfigProxy),
@@ -1346,13 +1353,13 @@ contract Deploy is Deployer {
             _implementation: l1StandardBridge,
             _innerCallData: abi.encodeCall(
                 L1StandardBridge.initialize,
-                    (
-                        L1CrossDomainMessenger(l1CrossDomainMessengerProxy),
-                        SuperchainConfig(superchainConfigProxy),
-                        SystemConfig(systemConfigProxy)
-                    )
+                (
+                    L1CrossDomainMessenger(l1CrossDomainMessengerProxy),
+                    SuperchainConfig(superchainConfigProxy),
+                    SystemConfig(systemConfigProxy)
                 )
-            });
+            )
+        });
         // Retrieve and log the version of the upgraded L1StandardBridge.
         string memory version = L1StandardBridge(payable(l1StandardBridgeProxy)).version();
         console.log("L1StandardBridge version: %s", version);
@@ -1474,7 +1481,6 @@ contract Deploy is Deployer {
                 require(l1CrossDomainMessenger != address(0), "L1CrossDomainMessenger deployment failed");
                 save("L1CrossDomainMessenger", l1CrossDomainMessenger);
                 console.log("L1CrossDomainMessenger deployed at %s", l1CrossDomainMessenger);
-
             }
         }
 
@@ -1501,10 +1507,9 @@ contract Deploy is Deployer {
             });
         }
         require(
-            keccak256(bytes(proxyAdmin.implementationName(l1CrossDomainMessengerProxy))) ==
-            keccak256(bytes(contractName))
+            keccak256(bytes(proxyAdmin.implementationName(l1CrossDomainMessengerProxy)))
+                == keccak256(bytes(contractName))
         );
-
 
         _upgradeAndCallViaSafe({
             _proxy: payable(l1CrossDomainMessengerProxy),
@@ -1657,10 +1662,12 @@ contract Deploy is Deployer {
                 console.log("Using existing implementation from JSON");
             } else {
                 console.log("Implementation from JSON not found on-chain, deploying new one");
-                optimismPortal2 = address(new OptimismPortal2{ salt: _implSalt() }({
-            _proofMaturityDelaySeconds: cfg.proofMaturityDelaySeconds(),
-            _disputeGameFinalityDelaySeconds: cfg.disputeGameFinalityDelaySeconds()
-        }));
+                optimismPortal2 = address(
+                    new OptimismPortal2{ salt: _implSalt() }({
+                        _proofMaturityDelaySeconds: cfg.proofMaturityDelaySeconds(),
+                        _disputeGameFinalityDelaySeconds: cfg.disputeGameFinalityDelaySeconds()
+                    })
+                );
                 require(optimismPortal2 != address(0), "OptimismPortal2 deployment failed");
                 save("OptimismPortal2", optimismPortal2);
                 console.log("OptimismPortal2 deployed at %s", optimismPortal2);

--- a/packages/tokamak/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/tokamak/contracts-bedrock/scripts/Deploy.s.sol
@@ -1204,10 +1204,7 @@ contract Deploy is Deployer {
             console.log("SystemConfig address from JSON: %s", systemConfig);
         }
 
-        _upgradeAndCallViaSafe({
-            _proxy: payable(systemConfigProxy),
-            _implementation: systemConfig,
-            _innerCallData: abi.encodeCall(
+        bytes memory _innerCallData = abi.encodeCall(
                 SystemConfig.initialize,
                 (
                     cfg.finalSystemOwner(),
@@ -1228,8 +1225,12 @@ contract Deploy is Deployer {
                         gasPayingToken: customGasTokenAddress,
                         nativeTokenAddress: l2NativeTokenAddress
                     })
-                )
-            )
+                ));
+
+        _upgradeAndCallViaSafe({
+            _proxy: payable(systemConfigProxy),
+            _implementation: systemConfig,
+            _innerCallData: _innerCallData
         });
         SystemConfig config = SystemConfig(systemConfigProxy);
         string memory version = config.version();

--- a/packages/tokamak/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/tokamak/contracts-bedrock/scripts/Deploy.s.sol
@@ -292,7 +292,7 @@ contract Deploy is Deployer {
     }
 
     /// @notice Read the JSON file once and store it in jsonCache to get the deployed implementation contract address
-    function setUp() public {
+    function getDeployment() public {
         uint256 chainid = block.chainid;
         /// After deployment to mainnet we will add path of deployment file
         // if (chainid == Chains.Mainnet) {
@@ -308,7 +308,7 @@ contract Deploy is Deployer {
         console.log("start of L1 Deploy!");
         // Get the deployment following the deploying network
         if (cfg.isFirstDeploy() == false) {
-            setUp();
+            getDeployment();
         }
         deploySafe("SystemOwnerSafe");
         console.log("deployed Safe!");

--- a/packages/tokamak/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/tokamak/contracts-bedrock/scripts/Deploy.s.sol
@@ -300,13 +300,13 @@ contract Deploy is Deployer {
     }
 
     /// @notice Read the JSON file once and store it in jsonCache to get the deployed implementation contract address
-    function getDeployment() public {
+    function getDeploymentReUse() public {
         uint256 chainid = block.chainid;
         /// After deployment to mainnet we will add path of deployment file
         // if (chainid == Chains.Mainnet) {
         //     jsonCache = vm.readFile("./")
         // }
-        if (cfg.isFirstDeploy() == false) {
+        if (cfg.reuseDeployment()) {
             if (chainid == Chains.Sepolia) {
                 jsonDeployment = vm.readFile("./deployments/thanos-stack-sepolia/address.json");
             }
@@ -332,8 +332,8 @@ contract Deploy is Deployer {
             }
         }
         // Get the deployment following the deploying network
-        if (cfg.isFirstDeploy() == false) {
-            getDeployment();
+        if (cfg.reuseDeployment()) {
+            getDeploymentReUse();
         }
         setupOpChain();
         console.log("set up op chain!");
@@ -423,7 +423,7 @@ contract Deploy is Deployer {
     function deployImplementations() public {
         console.log("Deploying implementations");
 
-        if (cfg.isFirstDeploy()) {
+        if (cfg.reuseDeployment() == false) {
             deploySystemConfig();
             deployL1StandardBridge();
             deployL1ERC721Bridge();
@@ -1034,9 +1034,7 @@ contract Deploy is Deployer {
 
         address disputeGameFactory;
 
-        if (cfg.isFirstDeploy()) {
-            disputeGameFactory = mustGetAddress("DisputeGameFactory");
-        } else {
+        if (cfg.reuseDeployment()) {
             address savedAddress = jsonDeployment.readAddress(".DisputeGameFactory");
             console.log("DisputeGameFactory address from JSON: %s", savedAddress);
 
@@ -1050,6 +1048,8 @@ contract Deploy is Deployer {
                 save("DisputeGameFactory", disputeGameFactory);
                 console.log("DisputeGameFactory deployed at %s", disputeGameFactory);
             }
+        } else {
+            disputeGameFactory = mustGetAddress("DisputeGameFactory");
         }
 
         _upgradeAndCallViaSafe({
@@ -1071,9 +1071,7 @@ contract Deploy is Deployer {
 
         address delayedWETH;
 
-        if (cfg.isFirstDeploy()) {
-            delayedWETH = mustGetAddress("DelayedWETH");
-        } else {
+        if (cfg.reuseDeployment()) {
             address savedAddress = jsonDeployment.readAddress(".DelayedWETH");
             console.log("DelayedWETH address from JSON: %s", savedAddress);
 
@@ -1087,6 +1085,8 @@ contract Deploy is Deployer {
                 save("DelayedWETH", delayedWETH);
                 console.log("DelayedWETH deployed at %s", delayedWETH);
             }
+        } else {
+            delayedWETH = mustGetAddress("DelayedWETH");
         }
 
         _upgradeAndCallViaSafe({
@@ -1113,9 +1113,7 @@ contract Deploy is Deployer {
 
         address delayedWETH;
 
-        if (cfg.isFirstDeploy()) {
-            delayedWETH = mustGetAddress("DelayedWETH");
-        } else {
+        if (cfg.reuseDeployment()) {
             address savedAddress = jsonDeployment.readAddress(".DelayedWETH");
             console.log("DelayedWETH address from JSON: %s", savedAddress);
 
@@ -1137,6 +1135,8 @@ contract Deploy is Deployer {
                 //     delayedWETH = mustGetAddress("DelayedWETH");
                 // }
             }
+        } else {
+            delayedWETH = mustGetAddress("DelayedWETH");
         }
 
         _upgradeAndCallViaSafe({
@@ -1200,9 +1200,7 @@ contract Deploy is Deployer {
 
         address anchorStateRegistry;
 
-        if (cfg.isFirstDeploy()) {
-            anchorStateRegistry = mustGetAddress("AnchorStateRegistry");
-        } else {
+        if (cfg.reuseDeployment()) {
             address savedAddress = jsonDeployment.readAddress(".AnchorStateRegistry");
             console.log("AnchorStateRegistry address from JSON: %s", savedAddress);
 
@@ -1220,6 +1218,8 @@ contract Deploy is Deployer {
                 save("AnchorStateRegistry", anchorStateRegistry);
                 console.log("AnchorStateRegistry deployed at %s", anchorStateRegistry);
             }
+        } else {
+             anchorStateRegistry = mustGetAddress("AnchorStateRegistry");
         }
 
         _upgradeAndCallViaSafe({
@@ -1253,9 +1253,7 @@ contract Deploy is Deployer {
 
         address systemConfig;
 
-        if (cfg.isFirstDeploy()) {
-            systemConfig = mustGetAddress("SystemConfig");
-        } else {
+        if (cfg.reuseDeployment()) {
             address savedAddress = jsonDeployment.readAddress(".SystemConfig");
             console.log("SystemConfig address from JSON: %s", savedAddress);
 
@@ -1269,6 +1267,8 @@ contract Deploy is Deployer {
                 save("SystemConfig", systemConfig);
                 console.log("SystemConfig deployed at %s", systemConfig);
             }
+        } else {
+            systemConfig = mustGetAddress("SystemConfig");
         }
 
         bytes memory _innerCallData = abi.encodeCall(
@@ -1322,9 +1322,7 @@ contract Deploy is Deployer {
 
         address l1StandardBridge;
 
-        if (cfg.isFirstDeploy()) {
-            l1StandardBridge = mustGetAddress("L1StandardBridge");
-        } else {
+        if (cfg.reuseDeployment()) {
             address savedAddress = jsonDeployment.readAddress(".L1StandardBridge");
             console.log("L1StandardBridge address from JSON: %s", savedAddress);
 
@@ -1338,6 +1336,8 @@ contract Deploy is Deployer {
                 save("L1StandardBridge", l1StandardBridge);
                 console.log("L1StandardBridge deployed at %s", l1StandardBridge);
             }
+        } else {
+            l1StandardBridge = mustGetAddress("L1StandardBridge");
         }
 
         // Set the proxy type.
@@ -1380,9 +1380,7 @@ contract Deploy is Deployer {
 
         address l1ERC721Bridge;
 
-        if (cfg.isFirstDeploy()) {
-            l1ERC721Bridge = mustGetAddress("L1ERC721Bridge");
-        } else {
+        if (cfg.reuseDeployment()) {
             address savedAddress = jsonDeployment.readAddress(".L1ERC721Bridge");
             console.log("L1ERC721Bridge address from JSON: %s", savedAddress);
 
@@ -1396,6 +1394,8 @@ contract Deploy is Deployer {
                 save("L1ERC721Bridge", l1ERC721Bridge);
                 console.log("L1ERC721Bridge deployed at %s", l1ERC721Bridge);
             }
+        } else {
+            l1ERC721Bridge = mustGetAddress("L1ERC721Bridge");
         }
 
         _upgradeAndCallViaSafe({
@@ -1422,9 +1422,7 @@ contract Deploy is Deployer {
 
         address optimismMintableERC20Factory;
 
-        if (cfg.isFirstDeploy()) {
-            optimismMintableERC20Factory = mustGetAddress("OptimismMintableERC20Factory");
-        } else {
+        if (cfg.reuseDeployment()) {
             address savedAddress = jsonDeployment.readAddress(".OptimismMintableERC20Factory");
             console.log("OptimismMintableERC20Factory address from JSON: %s", savedAddress);
 
@@ -1438,6 +1436,8 @@ contract Deploy is Deployer {
                 save("OptimismMintableERC20Factory", optimismMintableERC20Factory);
                 console.log("OptimismMintableERC20Factory deployed at %s", optimismMintableERC20Factory);
             }
+        } else {
+            optimismMintableERC20Factory = mustGetAddress("OptimismMintableERC20Factory");
         }
 
         _upgradeAndCallViaSafe({
@@ -1469,9 +1469,7 @@ contract Deploy is Deployer {
 
         address l1CrossDomainMessenger;
 
-        if (cfg.isFirstDeploy()) {
-            l1CrossDomainMessenger = mustGetAddress("L1CrossDomainMessenger");
-        } else {
+        if (cfg.reuseDeployment()) {
             address savedAddress = jsonDeployment.readAddress(".L1CrossDomainMessenger");
             console.log("L1CrossDomainMessenger address from JSON: %s", savedAddress);
 
@@ -1485,6 +1483,8 @@ contract Deploy is Deployer {
                 save("L1CrossDomainMessenger", l1CrossDomainMessenger);
                 console.log("L1CrossDomainMessenger deployed at %s", l1CrossDomainMessenger);
             }
+        } else {
+            l1CrossDomainMessenger = mustGetAddress("L1CrossDomainMessenger");
         }
 
         // Set the proxy type to RESOLVED if not already set.
@@ -1542,9 +1542,7 @@ contract Deploy is Deployer {
 
         address l2OutputOracle;
 
-        if (cfg.isFirstDeploy()) {
-            l2OutputOracle = mustGetAddress("L2OutputOracle");
-        } else {
+        if (cfg.reuseDeployment()) {
             address savedAddress = jsonDeployment.readAddress(".L2OutputOracle");
             console.log("L2OutputOracle address from JSON: %s", savedAddress);
 
@@ -1558,6 +1556,8 @@ contract Deploy is Deployer {
                 save("L2OutputOracle", l2OutputOracle);
                 console.log("L2OutputOracle deployed at %s", l2OutputOracle);
             }
+        } else {
+            l2OutputOracle = mustGetAddress("L2OutputOracle");
         }
 
         _upgradeAndCallViaSafe({
@@ -1602,10 +1602,7 @@ contract Deploy is Deployer {
         address optimismPortal;
 
         // Get the OptimismPortal implementation address based on deployment type.
-        if (cfg.isFirstDeploy()) {
-            // For initial deployment, use current deployment history
-            optimismPortal = mustGetAddress("OptimismPortal");
-        } else {
+        if (cfg.reuseDeployment()) {
             // For duplicate deployments, try to read from JSON
             address savedAddress = jsonDeployment.readAddress(".OptimismPortal");
             console.log("OptimismPortal address from JSON: %s", savedAddress);
@@ -1620,6 +1617,8 @@ contract Deploy is Deployer {
                 save("OptimismPortal", optimismPortal);
                 console.log("OptimismPortal deployed at %s", optimismPortal);
             }
+        } else {
+            optimismPortal = mustGetAddress("OptimismPortal");
         }
         // Upgrade the proxy with the new implementation and initialization data.
         _upgradeAndCallViaSafe({
@@ -1654,9 +1653,7 @@ contract Deploy is Deployer {
 
         address optimismPortal2;
 
-        if (cfg.isFirstDeploy()) {
-            optimismPortal2 = mustGetAddress("OptimismPortal2");
-        } else {
+        if (cfg.reuseDeployment()) {
             address savedAddress = jsonDeployment.readAddress(".OptimismPortal2");
             console.log("OptimismPortal2 address from JSON: %s", savedAddress);
 
@@ -1675,6 +1672,8 @@ contract Deploy is Deployer {
                 save("OptimismPortal2", optimismPortal2);
                 console.log("OptimismPortal2 deployed at %s", optimismPortal2);
             }
+        } else {
+            optimismPortal2 = mustGetAddress("OptimismPortal2");
         }
 
         _upgradeAndCallViaSafe({
@@ -1967,23 +1966,13 @@ contract Deploy is Deployer {
     function initializeDataAvailabilityChallenge() public broadcast {
         console.log("Upgrading and initializing DataAvailabilityChallenge proxy");
         address dataAvailabilityChallengeProxy = mustGetAddress("DataAvailabilityChallengeProxy");
+        address dataAvailabilityChallenge = mustGetAddress("DataAvailabilityChallenge");
 
         address finalSystemOwner = cfg.finalSystemOwner();
         uint256 daChallengeWindow = cfg.daChallengeWindow();
         uint256 daResolveWindow = cfg.daResolveWindow();
         uint256 daBondSize = cfg.daBondSize();
         uint256 daResolverRefundPercentage = cfg.daResolverRefundPercentage();
-
-        // Check if this is the first deployment.
-        bool isFirst = cfg.isFirstDeploy();
-
-        // For first deployment, use mustGetAddress; for duplicate deployments, read the address from JSON.
-        address dataAvailabilityChallenge = isFirst
-            ? mustGetAddress("DataAvailabilityChallenge")
-            : jsonDeployment.readAddress(".DataAvailabilityChallenge");
-        if (!isFirst) {
-            console.log("DataAvailabilityChallenge address from JSON: %s", dataAvailabilityChallenge);
-        }
 
         _upgradeAndCallViaSafe({
             _proxy: payable(dataAvailabilityChallengeProxy),

--- a/packages/tokamak/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/tokamak/contracts-bedrock/scripts/Deploy.s.sol
@@ -1125,16 +1125,17 @@ contract Deploy is Deployer {
                 console.log("Using existing implementation from JSON");
             } else {
                 // If we didn't deploy the DelayedWETH contract in initializeDelayedWETH(), deploy it here.
-                if (load("DelayedWETH") == address(0)) {
+                // if (load("DelayedWETH") == address(0)) {
                     console.log("Implementation from JSON not found on-chain, deploying new one");
                     delayedWETH = address(new DelayedWETH{ salt: _implSalt() }(cfg.faultGameWithdrawalDelay()));
                     require(delayedWETH != address(0), "DelayedWETH deployment failed");
                     save("DelayedWETH", delayedWETH);
                     console.log("DelayedWETH deployed at %s", delayedWETH);
                     // Import from deployment
-                } else {
-                    delayedWETH = mustGetAddress("DelayedWETH");
-                }
+                // }
+                // else {
+                //     delayedWETH = mustGetAddress("DelayedWETH");
+                // }
             }
         }
 
@@ -1332,8 +1333,10 @@ contract Deploy is Deployer {
                 console.log("Using existing implementation from JSON");
             } else {
                 console.log("Implementation from JSON not found on-chain, deploying new one");
-                l1StandardBridge = deployL1StandardBridge();
+                l1StandardBridge = address(new L1StandardBridge{ salt: _implSalt() }());
                 require(l1StandardBridge != address(0), "L1StandardBridge deployment failed");
+                save("L1StandardBridge", l1StandardBridge);
+                console.log("L1StandardBridge deployed at %s", l1StandardBridge);
             }
         }
 

--- a/packages/tokamak/contracts-bedrock/scripts/DeployConfig.s.sol
+++ b/packages/tokamak/contracts-bedrock/scripts/DeployConfig.s.sol
@@ -94,7 +94,7 @@ contract DeployConfig is Script {
 
     bool public useInterop;
     bool public devnet;
-    bool public isFirstDeploy;
+    bool public reuseDeployment;
 
     function read(string memory _path) public {
         console.log("DeployConfig: reading file %s", _path);
@@ -182,7 +182,7 @@ contract DeployConfig is Script {
 
         useInterop = _readOr(_json, "$.useInterop", false);
         devnet = _readOr(_json, "$.devnet", false);
-        isFirstDeploy = _readOr(_json, "$.isFirstDeploy", true);
+        reuseDeployment = _readOr(_json, "$.reuseDeployment", false);
     }
 
     function setNativeTokenAddress(address _nativeTokenAddress, string memory _path) public {

--- a/packages/tokamak/contracts-bedrock/scripts/DeployConfig.s.sol
+++ b/packages/tokamak/contracts-bedrock/scripts/DeployConfig.s.sol
@@ -94,6 +94,7 @@ contract DeployConfig is Script {
 
     bool public useInterop;
     bool public devnet;
+    bool public isFirstDeploy;
 
     function read(string memory _path) public {
         console.log("DeployConfig: reading file %s", _path);
@@ -181,6 +182,7 @@ contract DeployConfig is Script {
 
         useInterop = _readOr(_json, "$.useInterop", false);
         devnet = _readOr(_json, "$.devnet", false);
+        isFirstDeploy = _readOr(_json, "$.isFirstDeploy", true);
     }
 
     function setNativeTokenAddress(address _nativeTokenAddress, string memory _path) public {


### PR DESCRIPTION
# Context
Thanos Stack Optimization: I updated L1 deployment script to save resources such as gas fees and deployment time. The changed logic only applies when L2 is deployed more than twice on the same network (it is called “duplicate deployment”) The other case is called “initial deployment”.

## Impact
1. Gas: About 50% reduced (80053913 -> 42637728)
2. The number of txns while deployment: about 20% reduced (62 -> 51)

## Changes
1. Required new deploy config field: `reuseDeployment`. If true, we allow to re-use deployment. If false, all implementations and proxies are distributed without reuse.
2. When it is duplicate deployment, it load deployed addresses from JSON specified in advance during proxy initialization phase and use it.
3. Add `verifyImplementationExists()`: This function is to verify if the Implementation exists on-chain.

## Target contracts:
1. OptimismPortal
2. OptimismPortal2
3. SystemConfig
4. L1StandardBridge
5. L1ERC721Bridge
6. OptimismMintableERC20Factory
7. L1CrossDomainMessenger
8. L2OutputOracle
9. DisputeGameFactory
10. DelayedWETH
11. AnchorStateRegistry

## Deployed addresses with duplicate deployment
```json
{
  "AddressManager": "0x65B7143C6C4AfAF866b030B9BaD434910ee457A8",
  "AnchorStateRegistryProxy": "0x08b4B412fCDA996e33247A5c12F9D699130aa36b",
  "DelayedWETHProxy": "0xcA4b4218F2912176a89629bebCA7275Ed1331726",
  "DisputeGameFactoryProxy": "0x70862E956bAe6ca693973b006EfF21CD0016AfEe",
  "L1CrossDomainMessengerProxy": "0xffeE0bA0a0272A5B5e3Ece9a440599f3936950a4",
  "L1ERC721BridgeProxy": "0xb660a5df6A0c5Ab57d37eE5956Dec70ADCcC8098",
  "L1StandardBridgeProxy": "0x2eB0d32BBDc59ef37436B1DCDC269b0b2451638D",
  "L1UsdcBridge": "0xeEA591E17A2A4F4da5d45C72e205e93b81Ff2197",
  "L1UsdcBridgeProxy": "0x7f75055E890652edF41B34995490dBE268b35e7E",
  "L2OutputOracleProxy": "0x50Da4a45E168FC14e213fc56cBE3f84E9989a82e",
  "Mips": "0x4406B1Ae57ED2F26513E3b3a23629B64275D052A",
  "OptimismMintableERC20FactoryProxy": "0xc1F499949787D2db6680B17bdDcD078f6A292d89",
  "OptimismPortalProxy": "0x0bc13F8EcdAaF67A33a213E09Df968F42098421F",
  "PermissionedDelayedWETHProxy": "0x689F78E1fF5DA2857DA38a8ab0e6F9b2F3BF3341",
  "PreimageOracle": "0x25Ae44f3d88F28Cd654f9533af1e1A27d9d5bFb7",
  "ProtocolVersions": "0x6c14387d6F52A651faA6b7C6092C90397bcaed61",
  "ProtocolVersionsProxy": "0x789b22C0668fb8464675DEC43Ed5B5B47476CeAf",
  "ProxyAdmin": "0x427D59A944429833FC52f47EB8Bdf69090E188B3",
  "SafeProxyFactory": "0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2",
  "SafeSingleton": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552",
  "SuperchainConfig": "0xaf0AEFf049Ad28947049c08b43e65cc6b97D5337",
  "SuperchainConfigProxy": "0x442aAB45fd12FE44f7AeEc744C953660e441Be3b",
  "SystemConfigProxy": "0xA5f85db0ded2b36D6621de48e13860BD9192040c",
  "SystemOwnerSafe": "0xaf9487BA9A006eb22149774Eac55A46F4f81B2B2"
}
```


