### PR TITLE
Chore: remove warning message while building contracts

### DIFF
--- a/packages/tokamak/contracts-bedrock/foundry.toml
+++ b/packages/tokamak/contracts-bedrock/foundry.toml
@@ -33,7 +33,8 @@ libraries = ["src/tokamak-contracts/USDC/L2/tokamak-USDC/v2/FiatTokenV2_2.sol:Si
 
 ast = true
 evm_version = "cancun"
-ignored_error_codes = ["transient-storage", "code-size", "init-code-size"]
+ignored_error_codes = ["transient-storage", "code-size", "init-code-size", "license"]
+ignored_warnings_from = ["src", "test"]
 
 # Test / Script Runner Settings
 ffi = true

--- a/packages/tokamak/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/tokamak/contracts-bedrock/scripts/Deploy.s.sol
@@ -794,7 +794,7 @@ contract Deploy is Deployer {
         addr_ = address(versions);
     }
 
-    function getL2NativeToken() public returns (address) {
+    function getL2NativeToken() public view returns (address) {
         bool isForkPublicNetwork = vm.envOr("FORK_PUBLIC_NETWORK", false);
         if (isForkPublicNetwork) {
             address addr_ = vm.envAddress("L2_NATIVE_TOKEN");


### PR DESCRIPTION
It is related to https://github.com/tokamak-network/trh-sdk/issues/54. This change minimizes user confusion by avoiding displaying unnecessary logs while building the package '@tokamak-network/thanos-contracts'

### build log
```bash
> @tokamak-network/thanos-contracts@0.0.7 prebuild /Users/theo/workspace_tokamak/tokamak-thanos/packages/tokamak/contracts-bedrock
> ./scripts/checks/check-foundry-install.sh

Foundry version matches the expected version.

> @tokamak-network/thanos-contracts@0.0.7 build /Users/theo/workspace_tokamak/tokamak-thanos/packages/tokamak/contracts-bedrock
> forge build

[⠆] Compiling...
[⠰] Compiling 148 files with Solc 0.8.27
[⠔] Compiling 1 files with Solc 0.5.17
[⠒] Compiling 14 files with Solc 0.8.20
[⠑] Compiling 16 files with Solc 0.8.19
[⠘] Compiling 414 files with Solc 0.8.15
[⠃] Compiling 40 files with Solc 0.6.12
[⠢] Compiling 36 files with Solc 0.8.25
[⠒] Solc 0.5.17 finished in 163.66ms
[⠆] Solc 0.8.20 finished in 474.97ms
[⠔] Solc 0.8.19 finished in 1.10s
[⠰] Solc 0.6.12 finished in 2.30s
[⠒] Solc 0.8.25 finished in 5.16s
[⠒] Solc 0.8.27 finished in 6.31s
[⠃] Solc 0.8.15 finished in 219.31s
Compiler run successful!
```


