### PR TITLE
fix: cannot find artifact of L1UsdcBridge while building @tokamak-network/thanos-sdk

### DIFF
--- a/packages/tokamak/sdk/src/adapters/usdc-bridge.ts
+++ b/packages/tokamak/sdk/src/adapters/usdc-bridge.ts
@@ -1,6 +1,6 @@
 import { hexStringEquals } from '@tokamak-network/core-utils'
 import { Contract } from 'ethers'
-import l1UsdcBridgeArtifact from '@tokamak-network/thanos-contracts/forge-artifacts/L1UsdcBridge.sol/L1UsdcBridge.json'
+import l1UsdcBridgeArtifact from '@tokamak-network/thanos-contracts/forge-artifacts/L1UsdcBridge.sol/L1UsdcBridge.0.8.15.json'
 import l2UsdcBridgeArtifact from '@tokamak-network/thanos-contracts/forge-artifacts/L2UsdcBridge.sol/L2UsdcBridge.json'
 
 import { AddressLike } from '../interfaces'

--- a/packages/tokamak/sdk/src/utils/contracts.ts
+++ b/packages/tokamak/sdk/src/utils/contracts.ts
@@ -18,7 +18,7 @@ import { predeploys } from '@tokamak-network/core-utils'
 import disputeGameFactory from '@tokamak-network/thanos-contracts/forge-artifacts/DisputeGameFactory.sol/DisputeGameFactory.json'
 import optimismPortal2 from '@tokamak-network/thanos-contracts/forge-artifacts/OptimismPortal2.sol/OptimismPortal2.json'
 import faultDisputeGame from '@tokamak-network/thanos-contracts/forge-artifacts/FaultDisputeGame.sol/FaultDisputeGame.json'
-import l1UsdcBridge from '@tokamak-network/thanos-contracts/forge-artifacts/L1UsdcBridge.sol/L1UsdcBridge.json'
+import l1UsdcBridge from '@tokamak-network/thanos-contracts/forge-artifacts/L1UsdcBridge.sol/L1UsdcBridge.0.8.15.json'
 import l2UsdcBridge from '@tokamak-network/thanos-contracts/forge-artifacts/L2UsdcBridge.sol/L2UsdcBridge.json'
 
 import { toAddress } from './coercion'


### PR DESCRIPTION
The forge 1.0.0 (e144b82070619b6e10485c38734b4d4d45aebe04) generates artifacts by compiler version according to the dependency using `forge build` command. This PR is for resolving build errors by reflecting changes in @tokamak-network/thanos-sdk.
* Related issue: https://github.com/tokamak-network/trh-sdk/issues/67