### PR TITLE
feat: add tokamak-deployer CLI binary for L1 contract deployment

### DIFF
--- a/.github/workflows/release-deployer.yml
+++ b/.github/workflows/release-deployer.yml
@@ -17,6 +17,17 @@ jobs:
         with:
           go-version: '1.22'
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: packages/tokamak/contracts-bedrock/pnpm-lock.yaml
+
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,9 +20,6 @@ builds:
     goarch:
       - amd64
       - arm64
-    ignore:
-      - goos: linux
-        goarch: arm64
 
 archives:
   - id: tokamak-deployer


### PR DESCRIPTION
## Summary

- `cmd/tokamak-deployer`: L1 컨트랙트 배포 및 genesis 생성을 위한 독립 Go CLI 바이너리 추가
  - `deploy-contracts`: L1 RPC + private key + chain ID로 컨트랙트 배포 → `deploy-output.json`
  - `generate-genesis`: deploy output + rollup config → `genesis.json` / `rollup.json`
  - 컨트랙트 아티팩트를 바이너리에 embed하여 forge 없이 실행 가능
- `.github/workflows/release-deployer.yml`: `v*` 태그 push 시 goreleaser로 자동 릴리즈
- `.goreleaser.yml`: linux-amd64 / linux-arm64 / darwin-amd64 / darwin-arm64 빌드

## Related

- trh-sdk `deployer_binary.go`가 이 릴리즈에서 바이너리를 다운로드하여 사용
- Release: https://github.com/tokamak-network/tokamak-thanos/releases/tag/v1.0.0

## Test plan

- [ ] `v*` 태그 push 시 CI 워크플로우(`release-deployer.yml`) 정상 실행 확인
- [ ] goreleaser가 4개 플랫폼 바이너리 생성 확인 (linux-amd64, linux-arm64, darwin-amd64, darwin-arm64)
- [ ] trh-sdk를 통한 L2 배포 시 바이너리 다운로드 및 L1 컨트랙트 배포 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)