### PR TITLE
fix(emergency-exit): security hardening — replay, proof verification, activation, alias

### DIFF
--- a/packages/tokamak/contracts-bedrock/src/emergency-exit/AppExitCoordinator.sol
+++ b/packages/tokamak/contracts-bedrock/src/emergency-exit/AppExitCoordinator.sol
@@ -32,6 +32,7 @@ contract AppExitCoordinator is ReentrancyGuard {
     error NotGuardian();
     error TimelockNotElapsed();
     error UnknownBlock();
+    error EmergencyNotDeclared();
 
     // ── State ─────────────────────────────────────────────────────────────────
     struct TokenRecord {
@@ -50,6 +51,12 @@ contract AppExitCoordinator is ReentrancyGuard {
     address public guardian;
     uint256 public constant REGISTRATION_DELAY = 48 hours;
 
+    /// @notice The single finalized L2 block height that all proofs are checked against.
+    ///         Zero until the guardian declares the emergency snapshot. Pinning every exit to one
+    ///         protocol-set block (instead of a caller-supplied block) is what prevents the same
+    ///         L2 balance from being proven and claimed at many different blocks.
+    uint256 public emergencyBlockNumber;
+
     mapping(bytes32 => bool) public exitClaims;
 
     // ── Events ────────────────────────────────────────────────────────────────
@@ -65,6 +72,7 @@ contract AppExitCoordinator is ReentrancyGuard {
     event ReserveRecovered(address indexed token, address indexed to, uint256 amount);
     event RegistrarUpdated(address indexed newRegistrar);
     event GuardianUpdated(address indexed newGuardian);
+    event EmergencyDeclared(uint256 blockNumber);
 
     // ── Modifiers ─────────────────────────────────────────────────────────────
     modifier onlyRegistrar() {
@@ -127,11 +135,21 @@ contract AppExitCoordinator is ReentrancyGuard {
 
     // ── Emergency Exit ────────────────────────────────────────────────────────
 
+    /// @notice Declare the emergency snapshot block that all proofs are checked against.
+    ///         Guardian-only. Reverts unless the L2StateOracle already exposes a non-zero state
+    ///         root for `blockNumber`, so exits can only ever be enabled against a finalized block.
+    /// @param blockNumber The finalized L2 block height to freeze exits at.
+    function declareEmergency(uint256 blockNumber) external onlyGuardian {
+        _getStateRoot(blockNumber); // reverts UnknownBlock if the root is unknown / zero
+        emergencyBlockNumber = blockNumber;
+        emit EmergencyDeclared(blockNumber);
+    }
+
     /// @notice Bundle proof data to reduce exitViaProof stack depth.
+    /// @dev No block number: all proofs are checked against the protocol-set `emergencyBlockNumber`.
     struct ExitProofRequest {
         address user;
         uint256 amount;
-        uint256 blockNumber;
         bytes accountStateRlp;
         bytes[] accountProof;
         bytes[] storageProof;
@@ -142,7 +160,7 @@ contract AppExitCoordinator is ReentrancyGuard {
     ///         from the emergency reserve immediately (no 7-day DTD).
     ///
     ///         Off-chain flow:
-    ///         1. User calls eth_getProof(l2Token, [balanceSlot], blockNumber) on L2 RPC
+    ///         1. User calls eth_getProof(l2Token, [balanceSlot], emergencyBlockNumber) on L2 RPC
     ///         2. Response includes accountProof, storageProof, and account state
     ///         3. User submits exitViaProof() on L1 with the proof data
     ///
@@ -153,9 +171,10 @@ contract AppExitCoordinator is ReentrancyGuard {
     ) external nonReentrant {
         TokenRecord storage rec = registry[l2Token];
         if (!rec.active) revert NotActive();
+        if (emergencyBlockNumber == 0) revert EmergencyNotDeclared();
 
-        // 1. Get finalized state root
-        bytes32 stateRoot = _getStateRoot(req.blockNumber);
+        // 1. Get the finalized state root for the protocol-set emergency snapshot block.
+        bytes32 stateRoot = _getStateRoot(emergencyBlockNumber);
 
         // 2. Verify MPT proofs (account state + storage slot)
         bytes32 storageKey = keccak256(abi.encode(req.user, rec.storageSlot));
@@ -169,8 +188,9 @@ contract AppExitCoordinator is ReentrancyGuard {
             req.amount
         );
 
-        // 3. Prevent double claims
-        bytes32 claimKey = keccak256(abi.encode(l2Token, req.user, req.blockNumber));
+        // 3. Prevent double claims. The key is (token, user) only — the snapshot block is fixed,
+        //    so the same balance cannot be re-proven at a different block to bypass this guard.
+        bytes32 claimKey = keccak256(abi.encode(l2Token, req.user));
         if (exitClaims[claimKey]) revert AlreadyClaimed();
         exitClaims[claimKey] = true;
 

--- a/packages/tokamak/contracts-bedrock/src/emergency-exit/AppExitCoordinator.sol
+++ b/packages/tokamak/contracts-bedrock/src/emergency-exit/AppExitCoordinator.sol
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import { EmergencyExitProof } from "../libraries/EmergencyExitProof.sol";
+
+/// @title AppExitCoordinator
+/// @notice L1 coordinator for the resolver exit path.
+///         Handles existing ERC-20 contracts that cannot be modified to implement
+///         IEmergencyExitable. Users submit MPT storage proofs to verify their
+///         L2 balance against a finalized state root.
+///
+///         Flow:
+///         1. Tokamak registrar registers L2 tokens with their balance storage slot
+///         2. After 48h timelock, anyone can activate the token
+///         3. User collects proof off-chain via eth_getProof
+///         4. User calls exitViaProof() with proof → EmergencyReserve pays out immediately
+///
+/// @dev This contract uses L2StateOracle to read finalized L2 state roots.
+///      The L2StateOracle is an L1 contract that mirrors L2 block state roots.
+contract AppExitCoordinator is ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    // ── Errors ────────────────────────────────────────────────────────────────
+    error NotActive();
+    error ProofInvalid();
+    error AlreadyClaimed();
+    error InvalidParameter();
+    error NotRegistrar();
+    error NotGuardian();
+    error TimelockNotElapsed();
+    error UnknownBlock();
+
+    // ── State ─────────────────────────────────────────────────────────────────
+    struct TokenRecord {
+        address l1Token;
+        uint256 storageSlot;
+        bool active;
+        uint64 activatesAt;
+    }
+
+    /// @notice L2StateOracle on L1 — provides finalized L2 state roots.
+    address public immutable l2StateOracle;
+
+    mapping(address => TokenRecord) public registry;
+
+    address public registrar;
+    address public guardian;
+    uint256 public constant REGISTRATION_DELAY = 48 hours;
+
+    mapping(bytes32 => bool) public exitClaims;
+
+    // ── Events ────────────────────────────────────────────────────────────────
+    event TokenRegistered(
+        address indexed l2Token,
+        address indexed l1Token,
+        uint256 storageSlot,
+        uint64 activatedAt
+    );
+    event TokenActivated(address indexed l2Token, uint64 activatedAt);
+    event TokenCancelled(address indexed l2Token);
+    event ExitClaimed(address indexed l2Token, address indexed user, uint256 amount);
+    event ReserveRecovered(address indexed token, address indexed to, uint256 amount);
+    event RegistrarUpdated(address indexed newRegistrar);
+    event GuardianUpdated(address indexed newGuardian);
+
+    // ── Modifiers ─────────────────────────────────────────────────────────────
+    modifier onlyRegistrar() {
+        if (msg.sender != registrar) revert NotRegistrar();
+        _;
+    }
+
+    modifier onlyGuardian() {
+        if (msg.sender != guardian) revert NotGuardian();
+        _;
+    }
+
+    // ── Constructor ───────────────────────────────────────────────────────────
+    constructor(
+        address _l2StateOracle,
+        address _registrar,
+        address _guardian
+    ) {
+        if (_l2StateOracle == address(0)) revert InvalidParameter();
+        if (_registrar == address(0)) revert InvalidParameter();
+        if (_guardian == address(0)) revert InvalidParameter();
+
+        l2StateOracle = _l2StateOracle;
+        registrar = _registrar;
+        guardian = _guardian;
+    }
+
+    // ── Token Registration ────────────────────────────────────────────────────
+
+    function registerToken(
+        address l2Token,
+        address l1Token,
+        uint256 storageSlot
+    ) external onlyRegistrar {
+        TokenRecord storage rec = registry[l2Token];
+        if (rec.active) revert NotActive();
+
+        uint64 activatedAt = uint64(block.timestamp) + uint64(REGISTRATION_DELAY);
+        rec.l1Token = l1Token;
+        rec.storageSlot = storageSlot;
+        rec.activatesAt = activatedAt;
+
+        emit TokenRegistered(l2Token, l1Token, storageSlot, activatedAt);
+    }
+
+    function cancelRegistration(address l2Token) external onlyGuardian {
+        delete registry[l2Token];
+        emit TokenCancelled(l2Token);
+    }
+
+    function activateToken(address l2Token) external {
+        TokenRecord storage rec = registry[l2Token];
+        if (rec.active) revert NotActive();
+        if (block.timestamp < rec.activatesAt) revert TimelockNotElapsed();
+
+        rec.active = true;
+        rec.activatesAt = uint64(block.timestamp);
+        emit TokenActivated(l2Token, rec.activatesAt);
+    }
+
+    // ── Emergency Exit ────────────────────────────────────────────────────────
+
+    /// @notice Bundle proof data to reduce exitViaProof stack depth.
+    struct ExitProofRequest {
+        address user;
+        uint256 amount;
+        uint256 blockNumber;
+        bytes accountStateRlp;
+        bytes[] accountProof;
+        bytes[] storageProof;
+    }
+
+    /// @notice Execute an exit using a Merkle proof of the user's L2 balance.
+    ///         Verifies the proof against a finalized state root and pays out
+    ///         from the emergency reserve immediately (no 7-day DTD).
+    ///
+    ///         Off-chain flow:
+    ///         1. User calls eth_getProof(l2Token, [balanceSlot], blockNumber) on L2 RPC
+    ///         2. Response includes accountProof, storageProof, and account state
+    ///         3. User submits exitViaProof() on L1 with the proof data
+    ///
+    /// @dev The request struct bundles all proof parameters to keep stack depth low.
+    function exitViaProof(
+        address l2Token,
+        ExitProofRequest calldata req
+    ) external nonReentrant {
+        TokenRecord storage rec = registry[l2Token];
+        if (!rec.active) revert NotActive();
+
+        // 1. Get finalized state root
+        bytes32 stateRoot = _getStateRoot(req.blockNumber);
+
+        // 2. Verify MPT proofs (account state + storage slot)
+        bytes32 storageKey = keccak256(abi.encode(req.user, rec.storageSlot));
+        EmergencyExitProof.verifyProofs(
+            stateRoot,
+            l2Token,
+            req.accountStateRlp,
+            req.accountProof,
+            storageKey,
+            req.storageProof,
+            req.amount
+        );
+
+        // 3. Prevent double claims
+        bytes32 claimKey = keccak256(abi.encode(l2Token, req.user, req.blockNumber));
+        if (exitClaims[claimKey]) revert AlreadyClaimed();
+        exitClaims[claimKey] = true;
+
+        // 4. Pay out from reserve
+        IERC20(rec.l1Token).safeTransfer(req.user, req.amount);
+
+        emit ExitClaimed(l2Token, req.user, req.amount);
+    }
+
+    // ── Reserve Management ────────────────────────────────────────────────────
+
+    /// @notice Health check for the emergency reserve of a token.
+    /// @return balance  Current L1 token balance held by this contract.
+    /// @return minimum  Minimum required reserve (placeholder: zero).
+    /// @return healthy  True if reserve balance >= minimum.
+    function reserveHealthCheck(address l1Token)
+        external
+        view
+        returns (uint256 balance, uint256 minimum, bool healthy)
+    {
+        balance = IERC20(l1Token).balanceOf(address(this));
+        minimum = 0;
+        healthy = balance >= minimum;
+    }
+
+    /// @notice Recover unused reserve tokens after an emergency event.
+    /// @param token  The L1 ERC-20 token to recover.
+    /// @param amount The amount to recover.
+    function recoverReserve(address token, uint256 amount) external onlyRegistrar {
+        IERC20(token).safeTransfer(msg.sender, amount);
+        emit ReserveRecovered(token, msg.sender, amount);
+    }
+
+    // ── Admin ─────────────────────────────────────────────────────────────────
+
+    function setRegistrar(address newRegistrar) external {
+        if (msg.sender != registrar) revert NotRegistrar();
+        registrar = newRegistrar;
+        emit RegistrarUpdated(newRegistrar);
+    }
+
+    function setGuardian(address newGuardian) external {
+        if (msg.sender != registrar) revert NotRegistrar();
+        guardian = newGuardian;
+        emit GuardianUpdated(newGuardian);
+    }
+
+    // ── Internal ──────────────────────────────────────────────────────────────
+
+    function _getStateRoot(uint256 blockNumber) internal view returns (bytes32 stateRoot) {
+        (bool success, bytes memory data) = l2StateOracle.staticcall(
+            abi.encodeWithSignature("getStateRoot(uint256)", blockNumber)
+        );
+        if (!success || data.length < 32) revert UnknownBlock();
+        stateRoot = abi.decode(data, (bytes32));
+        if (stateRoot == bytes32(0)) revert UnknownBlock();
+    }
+}

--- a/packages/tokamak/contracts-bedrock/src/emergency-exit/AppExitCoordinator.sol
+++ b/packages/tokamak/contracts-bedrock/src/emergency-exit/AppExitCoordinator.sol
@@ -25,6 +25,7 @@ contract AppExitCoordinator is ReentrancyGuard {
 
     // ── Errors ────────────────────────────────────────────────────────────────
     error NotActive();
+    error NotRegistered();
     error ProofInvalid();
     error AlreadyClaimed();
     error InvalidParameter();
@@ -125,6 +126,9 @@ contract AppExitCoordinator is ReentrancyGuard {
 
     function activateToken(address l2Token) external {
         TokenRecord storage rec = registry[l2Token];
+        // A never-registered token has a zero record; its activatesAt is 0, which would otherwise
+        // pass the timelock check below and flip `active` true for an unregistered (l1Token == 0) entry.
+        if (rec.l1Token == address(0)) revert NotRegistered();
         if (rec.active) revert NotActive();
         if (block.timestamp < rec.activatesAt) revert TimelockNotElapsed();
 

--- a/packages/tokamak/contracts-bedrock/src/emergency-exit/AppExitCoordinator.sol
+++ b/packages/tokamak/contracts-bedrock/src/emergency-exit/AppExitCoordinator.sol
@@ -34,6 +34,7 @@ contract AppExitCoordinator is ReentrancyGuard {
     error TimelockNotElapsed();
     error UnknownBlock();
     error EmergencyNotDeclared();
+    error EmergencyAlreadyDeclared();
 
     // ── State ─────────────────────────────────────────────────────────────────
     struct TokenRecord {
@@ -144,6 +145,7 @@ contract AppExitCoordinator is ReentrancyGuard {
     ///         root for `blockNumber`, so exits can only ever be enabled against a finalized block.
     /// @param blockNumber The finalized L2 block height to freeze exits at.
     function declareEmergency(uint256 blockNumber) external onlyGuardian {
+        if (emergencyBlockNumber != 0) revert EmergencyAlreadyDeclared();
         _getStateRoot(blockNumber); // reverts UnknownBlock if the root is unknown / zero
         emergencyBlockNumber = blockNumber;
         emit EmergencyDeclared(blockNumber);

--- a/packages/tokamak/contracts-bedrock/src/emergency-exit/EmergencyExitableBase.sol
+++ b/packages/tokamak/contracts-bedrock/src/emergency-exit/EmergencyExitableBase.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { IEmergencyExitable } from "./IEmergencyExitable.sol";
+import { AddressAliasHelper } from "../vendor/AddressAliasHelper.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import { Predeploys } from "../libraries/Predeploys.sol";
+
+/// @title EmergencyExitableBase
+/// @notice Abstract base contract that implements IEmergencyExitable for L2 app contracts.
+///         Provides operator-gate-free emergency withdrawal path via Force TX:
+///         1. Resolve L1→L2 alias (if called via Force TX)
+///         2. Unwind user position to tokens + amount
+///         3. Push tokens to L2StandardBridge for L1 withdrawal
+/// @dev Subcontracts must implement _unwindPosition to define contract-specific
+///      position resolution logic (DEX LP burn, staking unstake, etc.).
+abstract contract EmergencyExitableBase is IEmergencyExitable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    /// @notice Error thrown when user has no balance to exit.
+    error ZeroBalance();
+
+    /// @notice Error thrown when position unwind returns zero amount.
+    error ExitEmpty();
+
+    /// @dev L2StandardBridge predeploy address — immutable constant, no import dependency.
+    address internal constant L2_STANDARD_BRIDGE = Predeploys.L2_STANDARD_BRIDGE;
+
+    /**
+     * @notice Unwind the user's position and return (token, amount).
+     *         Must transfer the user's position tokens into this contract before returning.
+     * @param user The address whose position to unwind (already resolved for alias).
+     * @return token   The L2 ERC-20 token address to bridge out.
+     * @return amount  The amount of token to withdraw.
+     */
+    function _unwindPosition(address user)
+        internal
+        virtual
+        returns (address token, uint256 amount);
+
+    /**
+     * @notice Execute emergency withdrawal for the caller.
+     *         Resolves L1→L2 alias, unwinds position, and pushes tokens to L2StandardBridge.
+     * @dev This function intentionally has NO operator controls (no whenNotPaused, onlyActive).
+     *      When called via Force TX (OptimismPortal2.depositTransaction), msg.sender
+     *      will be the aliased L1 address. We must undo the alias to get the real user.
+     */
+    function emergencyExit() external override nonReentrant {
+        // Force TX from L1 always causes msg.sender to be the aliased L1 address.
+        // We always undo the alias to get the real user.
+        address caller = AddressAliasHelper.undoL1ToL2Alias(msg.sender);
+
+        // Unwind position — this should:
+        // 1. Transfer user's position tokens (LP tokens, staking tokens, etc.) into this contract
+        // 2. Resolve them to underlying assets
+        // 3. Return the token address and amount to bridge out
+        (address token, uint256 amount) = _unwindPosition(caller);
+        if (amount == 0) revert ExitEmpty();
+
+        // Approve L2StandardBridge to pull the tokens, then trigger L1 withdrawal.
+        // The bridge will create a withdrawal message that can be proved + finalized on L1
+        // after the standard Fault Proof challenge period (7 days on mainnet).
+        IERC20(token).approve(L2_STANDARD_BRIDGE, amount);
+        IL2StandardBridge(L2_STANDARD_BRIDGE).withdraw(
+            token,
+            amount,
+            200_000, // gasLimit for the withdrawal message
+            ""       // calldata (not used for standard ERC-20 withdrawals)
+        );
+
+        emit EmergencyExited(caller, token, amount);
+    }
+
+    /**
+     * @notice Returns the L1/L2 token pair for this contract.
+     *         Subclasses should override with their specific token mapping.
+     */
+    function exitToken() external view virtual override returns (address l1Token, address l2Token) {
+        l1Token = address(0);
+        l2Token = address(0);
+    }
+
+    /**
+     * @notice Returns the exit preview for a user.
+     *         Subclasses should override with their specific balance calculation.
+     */
+    function exitPreview(address user) external view virtual override returns (uint256 amount) {
+        amount = 0;
+    }
+}
+
+/// @notice Interface for the L2StandardBridge predeploy.
+///         Minimal ABI for the withdraw() function only.
+interface IL2StandardBridge {
+    /// @notice Initiates a withdrawal of tokens from L2 to L1.
+    /// @param _token     L2 ERC-20 token address.
+    /// @param _amount    Amount to withdraw.
+    /// @param _gasLimit  Gas limit for the L1 bridge call.
+    /// @param _data      Additional calldata (unused for standard withdrawals).
+    function withdraw(address _token, uint256 _amount, uint256 _gasLimit, bytes calldata _data) external;
+}

--- a/packages/tokamak/contracts-bedrock/src/emergency-exit/EmergencyExitableBase.sol
+++ b/packages/tokamak/contracts-bedrock/src/emergency-exit/EmergencyExitableBase.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import { IEmergencyExitable } from "./IEmergencyExitable.sol";
-import { AddressAliasHelper } from "../vendor/AddressAliasHelper.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
@@ -42,15 +41,16 @@ abstract contract EmergencyExitableBase is IEmergencyExitable, ReentrancyGuard {
 
     /**
      * @notice Execute emergency withdrawal for the caller.
-     *         Resolves L1→L2 alias, unwinds position, and pushes tokens to L2StandardBridge.
+     *         Unwinds the caller's position and pushes tokens to L2StandardBridge.
      * @dev This function intentionally has NO operator controls (no whenNotPaused, onlyActive).
-     *      When called via Force TX (OptimismPortal2.depositTransaction), msg.sender
-     *      will be the aliased L1 address. We must undo the alias to get the real user.
+     *      The caller is msg.sender as-is. OptimismPortal aliases only L1 *contract* senders
+     *      (from = applyL1ToL2Alias(sender) iff sender != tx.origin), so an EOA Force TX arrives
+     *      un-aliased and a direct L2 call is already the owner; in both cases msg.sender is the
+     *      correct L2 identity. For an aliased L1 contract sender, the aliased address is its L2
+     *      identity. No alias undo is applied (undoing it unconditionally corrupts EOA callers).
      */
     function emergencyExit() external override nonReentrant {
-        // Force TX from L1 always causes msg.sender to be the aliased L1 address.
-        // We always undo the alias to get the real user.
-        address caller = AddressAliasHelper.undoL1ToL2Alias(msg.sender);
+        address caller = msg.sender;
 
         // Unwind position — this should:
         // 1. Transfer user's position tokens (LP tokens, staking tokens, etc.) into this contract

--- a/packages/tokamak/contracts-bedrock/src/emergency-exit/EmergencyExitableBase.sol
+++ b/packages/tokamak/contracts-bedrock/src/emergency-exit/EmergencyExitableBase.sol
@@ -62,7 +62,7 @@ abstract contract EmergencyExitableBase is IEmergencyExitable, ReentrancyGuard {
         // Approve L2StandardBridge to pull the tokens, then trigger L1 withdrawal.
         // The bridge will create a withdrawal message that can be proved + finalized on L1
         // after the standard Fault Proof challenge period (7 days on mainnet).
-        IERC20(token).approve(L2_STANDARD_BRIDGE, amount);
+        IERC20(token).safeApprove(L2_STANDARD_BRIDGE, amount);
         IL2StandardBridge(L2_STANDARD_BRIDGE).withdraw(
             token,
             amount,

--- a/packages/tokamak/contracts-bedrock/src/emergency-exit/IEmergencyExitable.sol
+++ b/packages/tokamak/contracts-bedrock/src/emergency-exit/IEmergencyExitable.sol
@@ -11,8 +11,9 @@ interface IEmergencyExitable {
 
     /// @notice Execute emergency withdrawal for the caller to L1.
     /// @dev Must be callable without operator gates (no whenNotPaused, onlyActive, etc.).
-    ///      On L2, when called via Force TX from L1, msg.sender will be the aliased address.
-    ///      Implementations must resolve the alias via AddressAliasHelper.undoL1ToL2Alias.
+    ///      Implementations should treat msg.sender as the L2 owner identity. OptimismPortal
+    ///      aliases only L1 contract senders, so an EOA Force TX arrives un-aliased; undoing the
+    ///      alias unconditionally would corrupt the caller. Do not apply undoL1ToL2Alias.
     function emergencyExit() external;
 
     /// @notice Returns the L1/L2 token pair this contract manages for exits.

--- a/packages/tokamak/contracts-bedrock/src/emergency-exit/IEmergencyExitable.sol
+++ b/packages/tokamak/contracts-bedrock/src/emergency-exit/IEmergencyExitable.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title IEmergencyExitable
+/// @notice Interface for L2 contracts that support emergency self-withdrawal to L1.
+///         Implemented by app contracts (DEX pools, staking contracts, games)
+///         to allow users to force-exit locked positions to L1 via Force TX.
+interface IEmergencyExitable {
+    /// @notice Emitted when a user successfully initiates an emergency exit.
+    event EmergencyExited(address indexed user, address indexed token, uint256 amount);
+
+    /// @notice Execute emergency withdrawal for the caller to L1.
+    /// @dev Must be callable without operator gates (no whenNotPaused, onlyActive, etc.).
+    ///      On L2, when called via Force TX from L1, msg.sender will be the aliased address.
+    ///      Implementations must resolve the alias via AddressAliasHelper.undoL1ToL2Alias.
+    function emergencyExit() external;
+
+    /// @notice Returns the L1/L2 token pair this contract manages for exits.
+    /// @return l1Token  The ERC-20 address on L1 (the destination of funds).
+    /// @return l2Token  The ERC-20 address on L2 (the source of funds).
+    function exitToken() external view returns (address l1Token, address l2Token);
+
+    /// @notice Returns the exit amount a user would receive right now.
+    /// @param user The address to query.
+    /// @return amount The user's exitable balance.
+    function exitPreview(address user) external view returns (uint256 amount);
+}

--- a/packages/tokamak/contracts-bedrock/src/libraries/EmergencyExitProof.sol
+++ b/packages/tokamak/contracts-bedrock/src/libraries/EmergencyExitProof.sol
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { MerkleTrie } from "./trie/MerkleTrie.sol";
+import { RLPReader } from "./rlp/RLPReader.sol";
+
+/// @title EmergencyExitProof
+/// @notice Verifies MPT storage proofs against a finalized L2 state root.
+///         Used by AppExitCoordinator to validate user balance claims in the resolver exit path.
+/// @dev Leverages the existing MerkleTrie library for Merkle-Patricia trie traversal
+///      and verification. Two-stage verification:
+///      1. Verify account state RLP against stateRoot using accountProof
+///      2. Extract storageRoot from account state, verify storage value using storageProof
+library EmergencyExitProof {
+    using RLPReader for bytes;
+    using RLPReader for RLPReader.RLPItem;
+
+    /// @notice Error thrown when MPT proof verification fails.
+    error ProofInvalid();
+
+    /// @notice Error thrown when storage value is less than expected.
+    /// @param actual   The actual storage value found.
+    /// @param expected The value the caller claimed.
+    error InsufficientBalance(uint256 actual, uint256 expected);
+
+    /// @notice Computes the storage slot hash for a mapping(address => uint256).
+    ///         This is the standard Solidity mapping layout: keccak256(abi.encode(user, slotIndex)).
+    /// @param user       The user address to look up.
+    /// @param slotIndex  The mapping slot index (e.g., 0 for a `mapping(address => uint256) balances` declaration).
+    /// @return slotHash  The keccak256 hash representing the storage slot key.
+    function balanceSlot(address user, uint256 slotIndex) external pure returns (bytes32 slotHash) {
+        return keccak256(abi.encode(user, slotIndex));
+    }
+
+    /// @notice Verifies a user's L2 storage balance against a finalized state root.
+    ///         Two-stage verification:
+    ///         1. Account state RLP → stateRoot via accountProof
+    ///         2. storageRoot (extracted from account state) → storage slot value via storageProof
+    /// @param stateRoot        Finalized L2 state root (from L2StateOracle on L1).
+    /// @param account          L2 contract address whose storage is being verified.
+    /// @param accountStateRlp  RLP-encoded account state: [nonce, balance, storageRoot, codeHash].
+    /// @param accountProof     MPT proof to verify accountStateRlp against stateRoot.
+    /// @param storageKey       keccak256(abi.encode(user, slotIndex)) — the storage slot to verify.
+    /// @param storageProof     MPT proof to verify the storage value at storageKey.
+    /// @param expectedValue    The balance value the caller claims to have.
+    /// @return actualValue     The actual storage value found (may differ from expectedValue).
+    function verifyProofs(
+        bytes32 stateRoot,
+        address account,
+        bytes memory accountStateRlp,
+        bytes[] memory accountProof,
+        bytes32 storageKey,
+        bytes[] memory storageProof,
+        uint256 expectedValue
+    ) external view returns (uint256 actualValue) {
+        // ── Step 1: Verify account state against stateRoot ─────────────────────
+        // The account key in the state trie is keccak256(accountAddress).
+        bytes memory accountKey = abi.encodePacked(keccak256(abi.encodePacked(account)));
+
+        if (
+            !MerkleTrie.verifyInclusionProof(
+                accountKey,
+                accountStateRlp,
+                accountProof,
+                stateRoot
+            )
+        ) {
+            revert ProofInvalid();
+        }
+
+        // ── Step 2: Extract storageRoot from account state ────────────────────
+        // OP Stack account state RLP format: [nonce, balance, storageRoot, codeHash]
+        // storageRoot is at index 2.
+        RLPReader.RLPItem[] memory accountFields = accountStateRlp.readList();
+        if (accountFields.length < 4) revert ProofInvalid();
+
+        bytes memory storageRootBytes = accountFields[2].readBytes();
+        if (storageRootBytes.length != 32) revert ProofInvalid();
+        bytes32 storageRoot = bytes32(storageRootBytes);
+
+        // ── Step 3: Verify storage slot value against storageRoot ─────────────
+        // storageProof is an MPT proof for the specific storage slot key.
+        // MerkleTrie.get() returns the value as raw bytes (already RLP-decoded).
+        bytes memory valueBytes = MerkleTrie.get(
+            abi.encodePacked(storageKey),
+            storageProof,
+            storageRoot
+        );
+
+        if (valueBytes.length == 0) revert ProofInvalid();
+
+        // Convert bytes to uint256 (the trie stores values as raw bytes after RLP decode).
+        // Storage values are always 32 bytes when padded from the L2 node.
+        if (valueBytes.length > 32) revert ProofInvalid();
+        assembly {
+            let free := mload(0x40)
+            // Zero out 32 bytes
+            mstore(free, 0)
+            // Copy value bytes to the front
+            let len := mload(valueBytes)
+            pop(
+                staticcall(
+                    gas(),
+                    0x4, // copy precompile isn't needed; just use mload/mstore
+                    add(valueBytes, 0x20),
+                    len,
+                    free,
+                    len
+                )
+            )
+            actualValue := shr(mul(8, sub(32, len)), mload(free))
+        }
+
+        if (actualValue < expectedValue) {
+            revert InsufficientBalance(actualValue, expectedValue);
+        }
+    }
+}

--- a/packages/tokamak/contracts-bedrock/src/libraries/EmergencyExitProof.sol
+++ b/packages/tokamak/contracts-bedrock/src/libraries/EmergencyExitProof.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { MerkleTrie } from "./trie/MerkleTrie.sol";
+import { SecureMerkleTrie } from "./trie/SecureMerkleTrie.sol";
 import { RLPReader } from "./rlp/RLPReader.sol";
 
 /// @title EmergencyExitProof
@@ -54,12 +54,10 @@ library EmergencyExitProof {
         uint256 expectedValue
     ) external view returns (uint256 actualValue) {
         // ── Step 1: Verify account state against stateRoot ─────────────────────
-        // The account key in the state trie is keccak256(accountAddress).
-        bytes memory accountKey = abi.encodePacked(keccak256(abi.encodePacked(account)));
-
+        // SecureMerkleTrie hashes the key (keccak256(account)), matching the Ethereum state trie.
         if (
-            !MerkleTrie.verifyInclusionProof(
-                accountKey,
+            !SecureMerkleTrie.verifyInclusionProof(
+                abi.encodePacked(account),
                 accountStateRlp,
                 accountProof,
                 stateRoot
@@ -79,9 +77,8 @@ library EmergencyExitProof {
         bytes32 storageRoot = bytes32(storageRootBytes);
 
         // ── Step 3: Verify storage slot value against storageRoot ─────────────
-        // storageProof is an MPT proof for the specific storage slot key.
-        // MerkleTrie.get() returns the value as raw bytes (already RLP-decoded).
-        bytes memory valueBytes = MerkleTrie.get(
+        // SecureMerkleTrie hashes the slot key (keccak256(storageKey)), matching the storage trie.
+        bytes memory valueBytes = SecureMerkleTrie.get(
             abi.encodePacked(storageKey),
             storageProof,
             storageRoot
@@ -89,20 +86,22 @@ library EmergencyExitProof {
 
         if (valueBytes.length == 0) revert ProofInvalid();
 
-        // Convert bytes to uint256 (the trie stores values as raw bytes after RLP decode).
-        // Storage values are always 32 bytes when padded from the L2 node.
-        if (valueBytes.length > 32) revert ProofInvalid();
+        // The storage trie leaf stores RLP(slotValue), so decode one more level to recover the raw
+        // big-endian value. Parsing the RLP-encoded blob directly would inflate the result by the
+        // length-prefix byte for any value >= 0x80, allowing an over-claim.
+        bytes memory slotValue = valueBytes.readBytes();
+        if (slotValue.length > 32) revert ProofInvalid();
         assembly {
             let free := mload(0x40)
             // Zero out 32 bytes
             mstore(free, 0)
-            // Copy value bytes to the front
-            let len := mload(valueBytes)
+            // Copy the trimmed value bytes to the front, then right-align into a uint256.
+            let len := mload(slotValue)
             pop(
                 staticcall(
                     gas(),
-                    0x4, // copy precompile isn't needed; just use mload/mstore
-                    add(valueBytes, 0x20),
+                    0x4, // identity precompile: copy len bytes
+                    add(slotValue, 0x20),
                     len,
                     free,
                     len

--- a/packages/tokamak/contracts-bedrock/test/emergency-exit/AppExitCoordinator.t.sol
+++ b/packages/tokamak/contracts-bedrock/test/emergency-exit/AppExitCoordinator.t.sol
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import { Test } from "forge-std/Test.sol";
+import { console2 as console } from "forge-std/console2.sol";
+import { AppExitCoordinator } from "src/emergency-exit/AppExitCoordinator.sol";
+import { TestERC20 } from "../mocks/TestERC20.sol";
+
+/// @title AppExitCoordinator_Unit_Test
+/// @notice Unit tests for AppExitCoordinator — registration, activation, exitViaProof.
+contract AppExitCoordinator_Test is Test {
+    AppExitCoordinator public coordinator;
+    TestERC20 public l1Token;
+
+    address public registrar = makeAddr("registrar");
+    address public guardian = makeAddr("guardian");
+    address public l2StateOracle = makeAddr("l2StateOracle");
+    address public l2Contract = makeAddr("l2Contract");
+    address public user = makeAddr("user");
+
+    uint256 public constant RESERVE_AMOUNT = 10000 ether;
+
+    function setUp() public {
+        // Deploy L1 token and fund coordinator
+        l1Token = new TestERC20();
+        l1Token.mint(address(this), RESERVE_AMOUNT);
+
+        // Deploy coordinator (l2StateOracle is mocked)
+        coordinator = new AppExitCoordinator(
+            l2StateOracle,
+            registrar,
+            guardian
+        );
+
+        // Fund coordinator with reserve
+        l1Token.transfer(address(coordinator), RESERVE_AMOUNT);
+
+        console.log("Coordinator balance:", l1Token.balanceOf(address(coordinator)));
+    }
+
+    // ── Constructor ──────────────────────────────────────────────────────────
+
+    function test_constructor_SetsImmutable() public {
+        assertEq(coordinator.l2StateOracle(), l2StateOracle, "l2StateOracle");
+        assertEq(coordinator.registrar(), registrar, "registrar");
+        assertEq(coordinator.guardian(), guardian, "guardian");
+        assertEq(coordinator.REGISTRATION_DELAY(), 48 hours, "timelock");
+    }
+
+    function test_constructor_Revert_ZeroStateOracle() public {
+        vm.expectRevert();
+        new AppExitCoordinator(address(0), registrar, guardian);
+    }
+
+    // ── Token Registration ───────────────────────────────────────────────────
+
+    function test_registerToken_ByRegistrar_Success() public {
+        vm.prank(registrar);
+        coordinator.registerToken(l2Contract, address(l1Token), 0);
+
+        // Should be registered but NOT active
+        (address l1TokenOut, uint256 slot, bool active, uint64 activatedAt) =
+            coordinator.registry(l2Contract);
+
+        assertEq(l1TokenOut, address(l1Token), "l1Token");
+        assertEq(slot, 0, "slot");
+        assert(!active);
+    }
+
+    function test_registerToken_NonRegistrar_Revert() public {
+        vm.prank(user);
+        vm.expectRevert();
+        coordinator.registerToken(l2Contract, address(l1Token), 0);
+    }
+
+    // ── Cancel Registration ──────────────────────────────────────────────────
+
+    function test_cancelRegistration_ByGuardian_Success() public {
+        // Register first
+        vm.prank(registrar);
+        coordinator.registerToken(l2Contract, address(l1Token), 0);
+
+        // Cancel
+        vm.prank(guardian);
+        coordinator.cancelRegistration(l2Contract);
+
+        // Should be deleted
+        (address l1TokenOut, , bool active, ) = coordinator.registry(l2Contract);
+        assertEq(l1TokenOut, address(0));
+        assert(!active);
+    }
+
+    function test_cancelRegistration_NonGuardian_Revert() public {
+        vm.prank(user);
+        vm.expectRevert();
+        coordinator.cancelRegistration(l2Contract);
+    }
+
+    // ── Token Activation ─────────────────────────────────────────────────────
+
+    function test_activateToken_TimelockNotElapsed_Revert() public {
+        vm.prank(registrar);
+        coordinator.registerToken(l2Contract, address(l1Token), 0);
+
+        // Try to activate immediately — should revert
+        vm.expectRevert(AppExitCoordinator.TimelockNotElapsed.selector);
+        coordinator.activateToken(l2Contract);
+    }
+
+    function test_activateToken_AfterTimelock_Success() public {
+        vm.prank(registrar);
+        coordinator.registerToken(l2Contract, address(l1Token), 0);
+
+        // Fast-forward past the 48h timelock
+        vm.warp(block.timestamp + 48 hours + 1 seconds);
+
+        // Anyone can activate
+        vm.prank(user);
+        coordinator.activateToken(l2Contract);
+
+        (, , bool active, ) = coordinator.registry(l2Contract);
+        assert(active);
+    }
+
+    function test_activateToken_AlreadyActive_Revert() public {
+        vm.prank(registrar);
+        coordinator.registerToken(l2Contract, address(l1Token), 0);
+
+        vm.warp(block.timestamp + 48 hours + 1 seconds);
+        coordinator.activateToken(l2Contract);
+
+        vm.expectRevert(AppExitCoordinator.NotActive.selector);
+        coordinator.activateToken(l2Contract);
+    }
+
+    // ── Exit via Proof ───────────────────────────────────────────────────────
+
+    /// @notice Test exitViaProof with a valid (mocked) proof.
+    ///         This test verifies the flow: register → activate → exit.
+    ///         Full MPT proof verification requires fork testing.
+    function test_exitViaProof_Flow_Complete() public {
+        // Step 1: Register token
+        vm.prank(registrar);
+        coordinator.registerToken(l2Contract, address(l1Token), 0);
+
+        // Step 2: Activate after timelock
+        vm.warp(block.timestamp + 48 hours + 1 seconds);
+        vm.prank(user);
+        coordinator.activateToken(l2Contract);
+
+        // Step 3: Verify token is active
+        (, , bool active, ) = coordinator.registry(l2Contract);
+        assert(active);
+
+        // exitViaProof requires actual proof data which we can't construct
+        // without a fork test. The function signature and modifiers are verified
+        // by the compilation passing.
+    }
+
+    function test_exitViaProof_NotActive_Revert() public {
+        // Register but don't activate
+        vm.prank(registrar);
+        coordinator.registerToken(l2Contract, address(l1Token), 0);
+
+        // Call exitViaProof — should revert because not active
+        AppExitCoordinator.ExitProofRequest memory req = AppExitCoordinator.ExitProofRequest({
+            user: user,
+            amount: 100,
+            blockNumber: 1,
+            accountStateRlp: "",
+            accountProof: new bytes[](0),
+            storageProof: new bytes[](0)
+        });
+
+        vm.expectRevert(AppExitCoordinator.NotActive.selector);
+        coordinator.exitViaProof(l2Contract, req);
+    }
+
+    // ── Reserve Management ───────────────────────────────────────────────────
+
+    function test_reserveHealthCheck_ReturnsValues() public {
+        (uint256 balance, uint256 minimum, bool healthy) =
+            coordinator.reserveHealthCheck(address(l1Token));
+
+        assertEq(balance, RESERVE_AMOUNT, "reserve balance");
+        assertEq(minimum, 0, "minimum");
+        assert(healthy);
+    }
+
+    function test_recoverReserve_ByRegistrar_Success() public {
+        // Registrar recovers unused reserve
+        uint256 before = l1Token.balanceOf(registrar);
+        vm.prank(registrar);
+        coordinator.recoverReserve(address(l1Token), 100);
+        assertEq(l1Token.balanceOf(registrar) - before, 100, "should receive tokens");
+    }
+
+    function test_recoverReserve_NonRegistrar_Revert() public {
+        vm.prank(user);
+        vm.expectRevert(AppExitCoordinator.NotRegistrar.selector);
+        coordinator.recoverReserve(address(l1Token), 100);
+    }
+
+    // ── Admin Updates ────────────────────────────────────────────────────────
+
+    function test_setRegistrar_ByRegistrar_Success() public {
+        address newRegistrar = makeAddr("newRegistrar");
+        vm.prank(registrar);
+        coordinator.setRegistrar(newRegistrar);
+        assertEq(coordinator.registrar(), newRegistrar, "registrar updated");
+    }
+
+    function test_setRegistrar_NonRegistrar_Revert() public {
+        vm.prank(user);
+        vm.expectRevert(AppExitCoordinator.NotRegistrar.selector);
+        coordinator.setRegistrar(makeAddr("newRegistrar"));
+    }
+
+    function test_setGuardian_ByRegistrar_Success() public {
+        address newGuardian = makeAddr("newGuardian");
+        vm.prank(registrar);
+        coordinator.setGuardian(newGuardian);
+        assertEq(coordinator.guardian(), newGuardian, "guardian updated");
+    }
+
+    function test_setGuardian_NonRegistrar_Revert() public {
+        vm.prank(user);
+        vm.expectRevert(AppExitCoordinator.NotRegistrar.selector);
+        coordinator.setGuardian(makeAddr("newGuardian"));
+    }
+}

--- a/packages/tokamak/contracts-bedrock/test/emergency-exit/AppExitCoordinator.t.sol
+++ b/packages/tokamak/contracts-bedrock/test/emergency-exit/AppExitCoordinator.t.sol
@@ -256,6 +256,16 @@ contract AppExitCoordinator_Test is Test {
         coordinator.declareEmergency(SNAPSHOT_BLOCK);
     }
 
+    function test_declareEmergency_AlreadyDeclared_Revert() public {
+        _mockStateRoot(bytes32(uint256(0xBEEF)));
+        vm.prank(guardian);
+        coordinator.declareEmergency(SNAPSHOT_BLOCK);
+
+        vm.prank(guardian);
+        vm.expectRevert(AppExitCoordinator.EmergencyAlreadyDeclared.selector);
+        coordinator.declareEmergency(SNAPSHOT_BLOCK);
+    }
+
     function test_declareEmergency_UnknownRoot_Revert() public {
         // No oracle mock: getStateRoot returns empty → UnknownBlock.
         vm.prank(guardian);

--- a/packages/tokamak/contracts-bedrock/test/emergency-exit/AppExitCoordinator.t.sol
+++ b/packages/tokamak/contracts-bedrock/test/emergency-exit/AppExitCoordinator.t.sol
@@ -4,7 +4,9 @@ pragma solidity ^0.8.15;
 import { Test } from "forge-std/Test.sol";
 import { console2 as console } from "forge-std/console2.sol";
 import { AppExitCoordinator } from "src/emergency-exit/AppExitCoordinator.sol";
+import { EmergencyExitProof } from "src/libraries/EmergencyExitProof.sol";
 import { TestERC20 } from "../mocks/TestERC20.sol";
+import { MptProofBuilder } from "./MptProofBuilder.sol";
 
 /// @title AppExitCoordinator_Unit_Test
 /// @notice Unit tests for AppExitCoordinator — registration, activation, exitViaProof.
@@ -19,6 +21,8 @@ contract AppExitCoordinator_Test is Test {
     address public user = makeAddr("user");
 
     uint256 public constant RESERVE_AMOUNT = 10000 ether;
+    uint256 public constant SNAPSHOT_BLOCK = 12345;
+    uint256 public constant SLOT = 0;
 
     function setUp() public {
         // Deploy L1 token and fund coordinator
@@ -166,7 +170,6 @@ contract AppExitCoordinator_Test is Test {
         AppExitCoordinator.ExitProofRequest memory req = AppExitCoordinator.ExitProofRequest({
             user: user,
             amount: 100,
-            blockNumber: 1,
             accountStateRlp: "",
             accountProof: new bytes[](0),
             storageProof: new bytes[](0)
@@ -227,5 +230,114 @@ contract AppExitCoordinator_Test is Test {
         vm.prank(user);
         vm.expectRevert(AppExitCoordinator.NotRegistrar.selector);
         coordinator.setGuardian(makeAddr("newGuardian"));
+    }
+
+    // ── HIGH-1: declareEmergency (guardian-set snapshot block) ────────────────
+
+    function test_declareEmergency_ByGuardian_Success() public {
+        _mockStateRoot(bytes32(uint256(0xBEEF)));
+        vm.prank(guardian);
+        coordinator.declareEmergency(SNAPSHOT_BLOCK);
+        assertEq(coordinator.emergencyBlockNumber(), SNAPSHOT_BLOCK, "snapshot block set");
+    }
+
+    function test_declareEmergency_NonGuardian_Revert() public {
+        _mockStateRoot(bytes32(uint256(0xBEEF)));
+        vm.prank(user);
+        vm.expectRevert(AppExitCoordinator.NotGuardian.selector);
+        coordinator.declareEmergency(SNAPSHOT_BLOCK);
+    }
+
+    function test_declareEmergency_UnknownRoot_Revert() public {
+        // No oracle mock: getStateRoot returns empty → UnknownBlock.
+        vm.prank(guardian);
+        vm.expectRevert(AppExitCoordinator.UnknownBlock.selector);
+        coordinator.declareEmergency(SNAPSHOT_BLOCK);
+    }
+
+    // ── HIGH-1: exitViaProof gated on emergency declaration ───────────────────
+
+    function test_exitViaProof_EmergencyNotDeclared_Revert() public {
+        _activate(l2Contract);
+        MptProofBuilder.Fixture memory f = MptProofBuilder.build(l2Contract, user, SLOT, 1000 ether);
+
+        vm.expectRevert(AppExitCoordinator.EmergencyNotDeclared.selector);
+        coordinator.exitViaProof(l2Contract, _req(f, user, 1000 ether));
+    }
+
+    // ── HIGH-1: end-to-end exit + replay prevention ───────────────────────────
+
+    function test_exitViaProof_Succeeds_AndPaysOut() public {
+        uint256 bal = 1000 ether;
+        MptProofBuilder.Fixture memory f = _arm(l2Contract, user, bal);
+
+        uint256 beforeBal = l1Token.balanceOf(user);
+        coordinator.exitViaProof(l2Contract, _req(f, user, bal));
+        assertEq(l1Token.balanceOf(user) - beforeBal, bal, "user should be paid the proven balance");
+    }
+
+    /// @notice The same balance cannot be claimed twice. Before the fix, a caller could pass a
+    ///         different blockNumber to mint a new claimKey and drain the reserve; the snapshot
+    ///         block is now fixed, so the (token, user) claim guard blocks the replay.
+    function test_exitViaProof_Replay_Revert() public {
+        uint256 bal = 1000 ether;
+        MptProofBuilder.Fixture memory f = _arm(l2Contract, user, bal);
+
+        coordinator.exitViaProof(l2Contract, _req(f, user, bal)); // first claim succeeds
+        vm.expectRevert(AppExitCoordinator.AlreadyClaimed.selector);
+        coordinator.exitViaProof(l2Contract, _req(f, user, bal)); // replay blocked
+    }
+
+    function test_exitViaProof_OverClaim_Revert() public {
+        uint256 bal = 1000 ether;
+        MptProofBuilder.Fixture memory f = _arm(l2Contract, user, bal);
+
+        vm.expectRevert(abi.encodeWithSelector(EmergencyExitProof.InsufficientBalance.selector, bal, bal + 1));
+        coordinator.exitViaProof(l2Contract, _req(f, user, bal + 1));
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// @notice Mock the L2StateOracle to return `root` for the snapshot block.
+    function _mockStateRoot(bytes32 root) internal {
+        vm.mockCall(
+            l2StateOracle,
+            abi.encodeWithSignature("getStateRoot(uint256)", SNAPSHOT_BLOCK),
+            abi.encode(root)
+        );
+    }
+
+    /// @notice Register and activate `token` against the L1 reserve token at SLOT.
+    function _activate(address token) internal {
+        vm.prank(registrar);
+        coordinator.registerToken(token, address(l1Token), SLOT);
+        vm.warp(block.timestamp + 48 hours + 1 seconds);
+        coordinator.activateToken(token);
+    }
+
+    /// @notice Full setup for an exit: build proof, activate token, mock oracle, declare emergency.
+    function _arm(address token, address account, uint256 balance)
+        internal
+        returns (MptProofBuilder.Fixture memory f)
+    {
+        f = MptProofBuilder.build(token, account, SLOT, balance);
+        _activate(token);
+        _mockStateRoot(f.stateRoot);
+        vm.prank(guardian);
+        coordinator.declareEmergency(SNAPSHOT_BLOCK);
+    }
+
+    function _req(MptProofBuilder.Fixture memory f, address account, uint256 amount)
+        internal
+        pure
+        returns (AppExitCoordinator.ExitProofRequest memory)
+    {
+        return AppExitCoordinator.ExitProofRequest({
+            user: account,
+            amount: amount,
+            accountStateRlp: f.accountStateRlp,
+            accountProof: f.accountProof,
+            storageProof: f.storageProof
+        });
     }
 }

--- a/packages/tokamak/contracts-bedrock/test/emergency-exit/AppExitCoordinator.t.sol
+++ b/packages/tokamak/contracts-bedrock/test/emergency-exit/AppExitCoordinator.t.sol
@@ -232,6 +232,14 @@ contract AppExitCoordinator_Test is Test {
         coordinator.setGuardian(makeAddr("newGuardian"));
     }
 
+    // ── C-2: activateToken on an unregistered token ───────────────────────────
+
+    function test_activateToken_Unregistered_Revert() public {
+        vm.warp(block.timestamp + 48 hours + 1 seconds);
+        vm.expectRevert(AppExitCoordinator.NotRegistered.selector);
+        coordinator.activateToken(makeAddr("ghostToken"));
+    }
+
     // ── HIGH-1: declareEmergency (guardian-set snapshot block) ────────────────
 
     function test_declareEmergency_ByGuardian_Success() public {

--- a/packages/tokamak/contracts-bedrock/test/emergency-exit/EmergencyExitProof.t.sol
+++ b/packages/tokamak/contracts-bedrock/test/emergency-exit/EmergencyExitProof.t.sol
@@ -3,87 +3,83 @@ pragma solidity ^0.8.15;
 
 import { Test } from "forge-std/Test.sol";
 import { EmergencyExitProof } from "src/libraries/EmergencyExitProof.sol";
-import { MerkleTrie } from "src/libraries/trie/MerkleTrie.sol";
-import { RLPReader } from "src/libraries/rlp/RLPReader.sol";
+import { MptProofBuilder } from "./MptProofBuilder.sol";
 
-/// @title EmergencyExitProof_Unit_Test
-/// @notice Tests for EmergencyExitProof library — slot computation, proof verification.
+/// @title EmergencyExitProof_Test
+/// @notice Tests for EmergencyExitProof — slot computation and two-stage MPT proof verification.
+/// @dev verifyProofs is exercised against real single-leaf secure tries built by MptProofBuilder,
+///      so the tests fail unless the keys are keccak256-hashed (SecureMerkleTrie) AND the storage
+///      value is RLP-decoded one extra level.
 contract EmergencyExitProof_Test is Test {
-    using RLPReader for bytes;
-    using RLPReader for RLPReader.RLPItem;
+    address internal l2Token = makeAddr("l2Token");
+    address internal user = makeAddr("user");
 
     // ── balanceSlot ──────────────────────────────────────────────────────────
 
     function test_balanceSlot_Deterministic() public {
-        address user = address(0x1234);
-        uint256 slotIndex = 0;
-
-        bytes32 result1 = EmergencyExitProof.balanceSlot(user, slotIndex);
-        bytes32 result2 = EmergencyExitProof.balanceSlot(user, slotIndex);
-        assertEq(bytes32(result1), bytes32(result2), "should be deterministic");
-
-        // Same user, different slot
-        bytes32 result3 = EmergencyExitProof.balanceSlot(user, 1);
-        assert(bytes32(result1) != bytes32(result3));
-
-        // Different user, same slot
-        bytes32 result4 = EmergencyExitProof.balanceSlot(address(0x5678), slotIndex);
-        assert(bytes32(result1) != bytes32(result4));
+        address u = address(0x1234);
+        bytes32 result1 = EmergencyExitProof.balanceSlot(u, 0);
+        assertEq(result1, EmergencyExitProof.balanceSlot(u, 0), "should be deterministic");
+        assert(result1 != EmergencyExitProof.balanceSlot(u, 1));
+        assert(result1 != EmergencyExitProof.balanceSlot(address(0x5678), 0));
     }
 
     function test_balanceSlot_Correctness() public {
-        address user = address(0xABCD);
-        uint256 slotIndex = 5;
-
-        bytes32 expected = keccak256(abi.encode(user, slotIndex));
-        assertEq(bytes32(EmergencyExitProof.balanceSlot(user, slotIndex)), expected, "should match keccak256(abi.encode)");
+        assertEq(
+            EmergencyExitProof.balanceSlot(address(0xABCD), 5),
+            keccak256(abi.encode(address(0xABCD), uint256(5))),
+            "should match keccak256(abi.encode)"
+        );
     }
 
-    // ── verifyProofs — simple MPT verification ───────────────────────────────
+    // ── verifyProofs — real two-stage MPT verification ────────────────────────
 
-    /// @notice Test verifyProofs with a known MPT.
-    ///         We create a simple trie, insert a key-value pair, then verify it.
-    function test_verifyProofs_ValidProof() public {
-        // Use a known state root from a test fixture.
-        // For this unit test, we create a minimal trie with one entry.
-        bytes32 stateRoot = _deploySimpleTrie();
+    /// @notice A valid proof for a multi-byte balance returns the exact balance.
+    ///         balance = 1000 (0x03E8) → storage leaf value = RLP(0x03E8) = 0x8203E8.
+    ///         A naive parser reading 0x8203E8 as an integer yields 8_521_704, so this passes
+    ///         only when the storage value is RLP-decoded correctly.
+    function test_verifyProofs_ValidProof_ReturnsExactBalance() public {
+        uint256 balance = 1000;
+        MptProofBuilder.Fixture memory f = MptProofBuilder.build(l2Token, user, 0, balance);
 
-        // The trie has: balanceSlot(user, 0) -> 1000
-        address account = makeAddr("contract");
-        uint256 slotIndex = 0;
-        bytes32 storageKey = EmergencyExitProof.balanceSlot(address(0xABCD), slotIndex);
-
-        // We need the account state RLP, accountProof, and storageProof.
-        // Since we deployed a simple trie, we can construct these manually.
-        // For now, this test verifies the interface works.
-
-        // In a real test, we'd use vm.createSelectFork to get proofs from an L2 node.
-        // This is a placeholder that verifies the function signature compiles.
+        uint256 got = EmergencyExitProof.verifyProofs(
+            f.stateRoot, f.account, f.accountStateRlp, f.accountProof, f.storageKey, f.storageProof, balance
+        );
+        assertEq(got, balance, "must return the exact, RLP-decoded balance");
     }
 
-    // ── ProofInvalid error ───────────────────────────────────────────────────
+    /// @notice Claiming more than the proven balance reverts (no over-claim).
+    function test_verifyProofs_OverClaim_Revert() public {
+        uint256 balance = 1000;
+        MptProofBuilder.Fixture memory f = MptProofBuilder.build(l2Token, user, 0, balance);
 
-    function test_verifyProofs_InvalidAccountProof_Revert() public {
-        // This test verifies that an invalid account proof causes revert.
-        // We'd need actual proof data to test this properly.
+        vm.expectRevert(
+            abi.encodeWithSelector(EmergencyExitProof.InsufficientBalance.selector, balance, balance + 1)
+        );
+        EmergencyExitProof.verifyProofs(
+            f.stateRoot, f.account, f.accountStateRlp, f.accountProof, f.storageKey, f.storageProof, balance + 1
+        );
     }
 
-    function test_verifyProofs_InvalidStorageProof_Revert() public {
-        // Verify that an invalid storage proof causes revert.
+    /// @notice A tampered storage proof (root mismatch) reverts.
+    function test_verifyProofs_TamperedStorageProof_Revert() public {
+        MptProofBuilder.Fixture memory f = MptProofBuilder.build(l2Token, user, 0, 1000);
+        f.storageProof[0][f.storageProof[0].length - 1] ^= bytes1(0x01);
+
+        vm.expectRevert();
+        EmergencyExitProof.verifyProofs(
+            f.stateRoot, f.account, f.accountStateRlp, f.accountProof, f.storageKey, f.storageProof, 1000
+        );
     }
 
-    function test_verifyProofs_InsufficientBalance_Revert() public {
-        // Verify that expectedValue > actualValue causes InsufficientBalance revert.
-    }
+    /// @notice A realistic 18-decimal balance is decoded exactly.
+    function test_verifyProofs_LargeBalance_ReturnsExactBalance() public {
+        uint256 balance = 1e18;
+        MptProofBuilder.Fixture memory f = MptProofBuilder.build(l2Token, user, 3, balance);
 
-    // ── Helpers ──────────────────────────────────────────────────────────────
-
-    /// @notice Deploy a simple MPT with one key-value pair.
-    ///         Returns the root hash of the trie.
-    function _deploySimpleTrie() internal returns (bytes32) {
-        // For a proper test, we need to build a trie and get proofs.
-        // This is simplified — a real test would use forge-std's vm.cheatcodes
-        // or fork testing with an actual L2 node.
-        return bytes32(0); // placeholder
+        uint256 got = EmergencyExitProof.verifyProofs(
+            f.stateRoot, f.account, f.accountStateRlp, f.accountProof, f.storageKey, f.storageProof, balance
+        );
+        assertEq(got, balance, "must decode an 18-decimal balance exactly");
     }
 }

--- a/packages/tokamak/contracts-bedrock/test/emergency-exit/EmergencyExitProof.t.sol
+++ b/packages/tokamak/contracts-bedrock/test/emergency-exit/EmergencyExitProof.t.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import { Test } from "forge-std/Test.sol";
+import { EmergencyExitProof } from "src/libraries/EmergencyExitProof.sol";
+import { MerkleTrie } from "src/libraries/trie/MerkleTrie.sol";
+import { RLPReader } from "src/libraries/rlp/RLPReader.sol";
+
+/// @title EmergencyExitProof_Unit_Test
+/// @notice Tests for EmergencyExitProof library — slot computation, proof verification.
+contract EmergencyExitProof_Test is Test {
+    using RLPReader for bytes;
+    using RLPReader for RLPReader.RLPItem;
+
+    // ── balanceSlot ──────────────────────────────────────────────────────────
+
+    function test_balanceSlot_Deterministic() public {
+        address user = address(0x1234);
+        uint256 slotIndex = 0;
+
+        bytes32 result1 = EmergencyExitProof.balanceSlot(user, slotIndex);
+        bytes32 result2 = EmergencyExitProof.balanceSlot(user, slotIndex);
+        assertEq(bytes32(result1), bytes32(result2), "should be deterministic");
+
+        // Same user, different slot
+        bytes32 result3 = EmergencyExitProof.balanceSlot(user, 1);
+        assert(bytes32(result1) != bytes32(result3));
+
+        // Different user, same slot
+        bytes32 result4 = EmergencyExitProof.balanceSlot(address(0x5678), slotIndex);
+        assert(bytes32(result1) != bytes32(result4));
+    }
+
+    function test_balanceSlot_Correctness() public {
+        address user = address(0xABCD);
+        uint256 slotIndex = 5;
+
+        bytes32 expected = keccak256(abi.encode(user, slotIndex));
+        assertEq(bytes32(EmergencyExitProof.balanceSlot(user, slotIndex)), expected, "should match keccak256(abi.encode)");
+    }
+
+    // ── verifyProofs — simple MPT verification ───────────────────────────────
+
+    /// @notice Test verifyProofs with a known MPT.
+    ///         We create a simple trie, insert a key-value pair, then verify it.
+    function test_verifyProofs_ValidProof() public {
+        // Use a known state root from a test fixture.
+        // For this unit test, we create a minimal trie with one entry.
+        bytes32 stateRoot = _deploySimpleTrie();
+
+        // The trie has: balanceSlot(user, 0) -> 1000
+        address account = makeAddr("contract");
+        uint256 slotIndex = 0;
+        bytes32 storageKey = EmergencyExitProof.balanceSlot(address(0xABCD), slotIndex);
+
+        // We need the account state RLP, accountProof, and storageProof.
+        // Since we deployed a simple trie, we can construct these manually.
+        // For now, this test verifies the interface works.
+
+        // In a real test, we'd use vm.createSelectFork to get proofs from an L2 node.
+        // This is a placeholder that verifies the function signature compiles.
+    }
+
+    // ── ProofInvalid error ───────────────────────────────────────────────────
+
+    function test_verifyProofs_InvalidAccountProof_Revert() public {
+        // This test verifies that an invalid account proof causes revert.
+        // We'd need actual proof data to test this properly.
+    }
+
+    function test_verifyProofs_InvalidStorageProof_Revert() public {
+        // Verify that an invalid storage proof causes revert.
+    }
+
+    function test_verifyProofs_InsufficientBalance_Revert() public {
+        // Verify that expectedValue > actualValue causes InsufficientBalance revert.
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /// @notice Deploy a simple MPT with one key-value pair.
+    ///         Returns the root hash of the trie.
+    function _deploySimpleTrie() internal returns (bytes32) {
+        // For a proper test, we need to build a trie and get proofs.
+        // This is simplified — a real test would use forge-std's vm.cheatcodes
+        // or fork testing with an actual L2 node.
+        return bytes32(0); // placeholder
+    }
+}

--- a/packages/tokamak/contracts-bedrock/test/emergency-exit/EmergencyExitableBase.t.sol
+++ b/packages/tokamak/contracts-bedrock/test/emergency-exit/EmergencyExitableBase.t.sol
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import { Test } from "forge-std/Test.sol";
+import { console2 as console } from "forge-std/console2.sol";
+import { EmergencyExitableBase, IEmergencyExitable, IL2StandardBridge } from "src/emergency-exit/EmergencyExitableBase.sol";
+import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
+import { TestERC20 } from "../mocks/TestERC20.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
+
+/// @notice Mock L2StandardBridge for testing — just records calls.
+contract MockL2StandardBridge {
+    address public lastToken;
+    uint256 public lastAmount;
+
+    function withdraw(address _token, uint256 _amount, uint256, bytes calldata) external {
+        lastToken = _token;
+        lastAmount = _amount;
+    }
+}
+
+/// @title EmergencyExitableBase_Unit_Test
+/// @notice Unit tests for EmergencyExitableBase — alias resolution, unwind, bridge withdraw.
+contract EmergencyExitableBase_Test is Test {
+    TestERC20 public token;
+    TestPool public pool;
+    MockL2StandardBridge public mockBridge;
+
+    address public user = makeAddr("user");
+    address public l1User = makeAddr("l1User");
+    address public aliasedL1User;
+
+    uint256 public constant USER_BALANCE = 1000 ether;
+
+    function setUp() public {
+        token = new TestERC20();
+        pool = new TestPool();
+        mockBridge = new MockL2StandardBridge();
+
+        // Deploy mock bridge at the L2StandardBridge predeploy address
+        bytes memory code = address(mockBridge).code;
+        vm.etch(Predeploys.L2_STANDARD_BRIDGE, code);
+
+        aliasedL1User = AddressAliasHelper.applyL1ToL2Alias(l1User);
+
+        // Mint LP tokens to user
+        token.mint(user, USER_BALANCE);
+        // Pool holds the pool address for exitToken mapping
+        pool.setPoolToken(address(token));
+
+        console.log("User LP balance:", token.balanceOf(user));
+        console.log("L1 user address:  ", l1User);
+        console.log("Aliased address:  ", aliasedL1User);
+    }
+
+    // ── emergencyExit() with direct call (tx.origin == msg.sender) ────────────
+
+    // ── emergencyExit() ───────────────────────────────────────────────────────
+
+    /// @notice emergencyExit always applies alias undo (Force TX design).
+    ///         In this test we mint to the resolved caller address so the call succeeds.
+    function test_emergencyExit_ResolvedCaller() public {
+        // emergencyExit always calls AddressAliasHelper.undoL1ToL2Alias(msg.sender).
+        // So the resolved caller is undoL1ToL2Alias(user).
+        // We mint tokens to that resolved address and call from user,
+        // and the exit should work.
+        address resolvedCaller = AddressAliasHelper.undoL1ToL2Alias(user);
+
+        // Mint LP tokens to the resolved caller address
+        token.mint(resolvedCaller, USER_BALANCE);
+
+        vm.prank(resolvedCaller);
+        token.approve(address(pool), USER_BALANCE);
+
+        // Call emergencyExit from user — it resolves back to resolvedCaller
+        vm.prank(user);
+        pool.emergencyExit();
+
+        // Verify the bridge withdraw was called with correct params (check at predeploy address)
+        MockL2StandardBridge bridge = MockL2StandardBridge(Predeploys.L2_STANDARD_BRIDGE);
+        assertEq(bridge.lastAmount(), USER_BALANCE, "bridge withdraw amount");
+        assertEq(bridge.lastToken(), address(token), "bridge withdraw token");
+        assertEq(token.balanceOf(resolvedCaller), 0, "resolved caller should have no LP tokens");
+    }
+
+    // ── emergencyExit() via Force TX simulation ───────────────────────────────
+
+    function test_emergencyExit_ForceTXAlias() public {
+        // Simulate Force TX from L1 user.
+        // msg.sender = aliasedL1User (the aliased address on L2).
+        // emergencyExit resolves it: undoL1ToL2Alias(aliasedL1User) = l1User.
+        // We need to mint tokens to l1User (the resolved caller).
+
+        address resolvedCaller = AddressAliasHelper.undoL1ToL2Alias(aliasedL1User);
+        assertEq(resolvedCaller, l1User, "alias resolve should return l1User");
+
+        token.mint(resolvedCaller, USER_BALANCE);
+
+        vm.prank(resolvedCaller);
+        token.approve(address(pool), USER_BALANCE);
+
+        // Force TX simulation: msg.sender is the aliased address
+        // emergencyExit resolves it back to l1User = resolvedCaller
+        vm.prank(aliasedL1User);
+        pool.emergencyExit();
+
+        // Verify the bridge withdraw was called with correct params
+        MockL2StandardBridge bridge = MockL2StandardBridge(Predeploys.L2_STANDARD_BRIDGE);
+        assertEq(bridge.lastAmount(), USER_BALANCE, "bridge withdraw amount");
+        assertEq(bridge.lastToken(), address(token), "bridge withdraw token");
+    }
+
+    // ── Zero balance ─────────────────────────────────────────────────────────
+
+    function test_emergencyExit_ZeroBalance_Revert() public {
+        address emptyUser = makeAddr("emptyUser");
+        vm.prank(emptyUser);
+        vm.expectRevert(EmergencyExitableBase.ExitEmpty.selector);
+        pool.emergencyExit();
+    }
+
+    // ── No approval ──────────────────────────────────────────────────────────
+
+    function test_emergencyExit_NoApproval_Revert() public {
+        vm.expectRevert(); // SafeERC20 allowance check fails
+        vm.prank(user);
+        pool.emergencyExit();
+    }
+
+    // ── Reentrancy protection ────────────────────────────────────────────────
+
+    function test_emergencyExit_ReentrancyGuard() public {
+        // ReentrancyGuard should prevent re-entry.
+        // Since EmergencyExitableBase calls forceApprove then bridge.withdraw,
+        // a malicious token that tries to call emergencyExit() again should revert.
+        // This test ensures the nonReentrant modifier is working.
+
+        // Note: full reentrancy test requires a malicious ERC-20.
+        // For now, verify the modifier exists on the function.
+        // The function signature includes nonReentrant, which is sufficient.
+    }
+
+    // ── Exit token preview ───────────────────────────────────────────────────
+
+    function test_exitPreview() public {
+        uint256 preview = pool.exitPreview(user);
+        assertEq(preview, USER_BALANCE, "exitPreview should match user balance");
+    }
+
+    // ── Exit token ───────────────────────────────────────────────────────────
+
+    function test_exitToken() public {
+        (address l1Token, address l2Token) = pool.exitToken();
+        assertEq(l2Token, address(token), "l2Token should match");
+    }
+}
+
+/// @notice Test pool that implements _unwindPosition for a DEX LP scenario.
+contract TestPool is EmergencyExitableBase {
+    TestERC20 public poolToken;
+
+    function setPoolToken(address _token) external {
+        poolToken = TestERC20(_token);
+    }
+
+    function _unwindPosition(address user)
+        internal
+        override
+        returns (address token, uint256 amount)
+    {
+        uint256 lpBalance = poolToken.balanceOf(user);
+        poolToken.transferFrom(user, address(this), lpBalance);
+        return (address(poolToken), lpBalance);
+    }
+
+    function exitToken() external view override returns (address l1Token, address l2Token) {
+        l2Token = address(poolToken);
+        l1Token = address(0); // placeholder
+    }
+
+    function exitPreview(address user) public view override returns (uint256 amount) {
+        return poolToken.balanceOf(user);
+    }
+}

--- a/packages/tokamak/contracts-bedrock/test/emergency-exit/EmergencyExitableBase.t.sol
+++ b/packages/tokamak/contracts-bedrock/test/emergency-exit/EmergencyExitableBase.t.sol
@@ -57,57 +57,42 @@ contract EmergencyExitableBase_Test is Test {
 
     // ── emergencyExit() ───────────────────────────────────────────────────────
 
-    /// @notice emergencyExit always applies alias undo (Force TX design).
-    ///         In this test we mint to the resolved caller address so the call succeeds.
-    function test_emergencyExit_ResolvedCaller() public {
-        // emergencyExit always calls AddressAliasHelper.undoL1ToL2Alias(msg.sender).
-        // So the resolved caller is undoL1ToL2Alias(user).
-        // We mint tokens to that resolved address and call from user,
-        // and the exit should work.
-        address resolvedCaller = AddressAliasHelper.undoL1ToL2Alias(user);
-
-        // Mint LP tokens to the resolved caller address
-        token.mint(resolvedCaller, USER_BALANCE);
-
-        vm.prank(resolvedCaller);
+    /// @notice emergencyExit credits msg.sender directly (no alias undo). A direct L2 caller —
+    ///         and an EOA Force TX, where OptimismPortal delivers the un-aliased EOA as msg.sender —
+    ///         unwinds its own position.
+    function test_emergencyExit_UsesMsgSenderDirectly() public {
+        // `user` already holds USER_BALANCE (minted in setUp).
+        vm.prank(user);
         token.approve(address(pool), USER_BALANCE);
 
-        // Call emergencyExit from user — it resolves back to resolvedCaller
         vm.prank(user);
         pool.emergencyExit();
 
-        // Verify the bridge withdraw was called with correct params (check at predeploy address)
         MockL2StandardBridge bridge = MockL2StandardBridge(Predeploys.L2_STANDARD_BRIDGE);
         assertEq(bridge.lastAmount(), USER_BALANCE, "bridge withdraw amount");
         assertEq(bridge.lastToken(), address(token), "bridge withdraw token");
-        assertEq(token.balanceOf(resolvedCaller), 0, "resolved caller should have no LP tokens");
+        assertEq(token.balanceOf(user), 0, "caller's LP tokens pulled");
     }
 
     // ── emergencyExit() via Force TX simulation ───────────────────────────────
 
-    function test_emergencyExit_ForceTXAlias() public {
-        // Simulate Force TX from L1 user.
-        // msg.sender = aliasedL1User (the aliased address on L2).
-        // emergencyExit resolves it: undoL1ToL2Alias(aliasedL1User) = l1User.
-        // We need to mint tokens to l1User (the resolved caller).
+    /// @notice An aliased L1-contract sender (Force TX from an L1 contract) is used as-is: the
+    ///         aliased address is its L2 identity, so no undo is applied. The owner of the position
+    ///         is whatever msg.sender the portal delivers.
+    function test_emergencyExit_AliasedSenderUsedAsIs() public {
+        token.mint(aliasedL1User, USER_BALANCE);
 
-        address resolvedCaller = AddressAliasHelper.undoL1ToL2Alias(aliasedL1User);
-        assertEq(resolvedCaller, l1User, "alias resolve should return l1User");
-
-        token.mint(resolvedCaller, USER_BALANCE);
-
-        vm.prank(resolvedCaller);
+        vm.prank(aliasedL1User);
         token.approve(address(pool), USER_BALANCE);
 
-        // Force TX simulation: msg.sender is the aliased address
-        // emergencyExit resolves it back to l1User = resolvedCaller
+        // Force TX simulation: msg.sender is the aliased address; caller == msg.sender (no undo).
         vm.prank(aliasedL1User);
         pool.emergencyExit();
 
-        // Verify the bridge withdraw was called with correct params
         MockL2StandardBridge bridge = MockL2StandardBridge(Predeploys.L2_STANDARD_BRIDGE);
         assertEq(bridge.lastAmount(), USER_BALANCE, "bridge withdraw amount");
         assertEq(bridge.lastToken(), address(token), "bridge withdraw token");
+        assertEq(token.balanceOf(aliasedL1User), 0, "aliased sender's LP tokens pulled");
     }
 
     // ── Zero balance ─────────────────────────────────────────────────────────

--- a/packages/tokamak/contracts-bedrock/test/emergency-exit/MptProofBuilder.sol
+++ b/packages/tokamak/contracts-bedrock/test/emergency-exit/MptProofBuilder.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+/// @title MptProofBuilder
+/// @notice Test helper that builds real single-leaf Merkle-Patricia trie proofs, using the same
+///         encoding a live Ethereum node produces:
+///           - account trie:  key = keccak256(account),        value = RLP([nonce, balance, storageRoot, codeHash])
+///           - storage trie:  key = keccak256(storageSlotKey),  value = RLP(slotValue)
+///         Both tries are "secure" (keys hashed with keccak256). Consumers verify that
+///         EmergencyExitProof / AppExitCoordinator hash the keys and RLP-decode the storage value.
+library MptProofBuilder {
+    struct Fixture {
+        bytes32 stateRoot;
+        address account;
+        bytes accountStateRlp;
+        bytes[] accountProof;
+        bytes32 storageKey;
+        bytes[] storageProof;
+    }
+
+    /// @notice Builds a coupled account+storage proof for `user`'s balance at `slotIndex` of `account`.
+    function build(address account, address user, uint256 slotIndex, uint256 balance)
+        internal
+        pure
+        returns (Fixture memory f)
+    {
+        f.account = account;
+        f.storageKey = keccak256(abi.encode(user, slotIndex));
+
+        // ── Storage trie (single leaf): secure key = keccak256(storageKey), value = RLP(balance) ──
+        bytes32 secureStorageKey = keccak256(abi.encodePacked(f.storageKey));
+        bytes memory storageLeaf = _leaf(secureStorageKey, _rlpStr(_trim(balance)));
+        bytes32 storageRoot = keccak256(storageLeaf);
+        f.storageProof = new bytes[](1);
+        f.storageProof[0] = storageLeaf;
+
+        // ── Account trie (single leaf): RLP([nonce=0, balance=0, storageRoot, codeHash]) ──
+        f.accountStateRlp = _rlpList(
+            bytes.concat(
+                _rlpStr(""), // nonce
+                _rlpStr(""), // balance
+                _rlpStr(abi.encodePacked(storageRoot)),
+                _rlpStr(abi.encodePacked(keccak256("")))
+            )
+        );
+        bytes memory accountLeaf = _leaf(keccak256(abi.encodePacked(account)), f.accountStateRlp);
+        f.stateRoot = keccak256(accountLeaf);
+        f.accountProof = new bytes[](1);
+        f.accountProof[0] = accountLeaf;
+    }
+
+    /// @notice Encodes a single even-length leaf node: RLP([0x20 || key32, valueField]).
+    function _leaf(bytes32 secureKey, bytes memory valueField) private pure returns (bytes memory) {
+        bytes memory path = bytes.concat(hex"20", secureKey); // HP prefix 0x20 = leaf, even length
+        return _rlpList(bytes.concat(_rlpStr(path), _rlpStr(valueField)));
+    }
+
+    // ── Minimal RLP encoder (lengths < 256, sufficient for single-leaf tries) ──
+
+    function _rlpStr(bytes memory b) private pure returns (bytes memory) {
+        if (b.length == 1 && uint8(b[0]) < 0x80) return b;
+        if (b.length <= 55) return bytes.concat(bytes1(uint8(0x80 + b.length)), b);
+        return bytes.concat(hex"b8", bytes1(uint8(b.length)), b);
+    }
+
+    function _rlpList(bytes memory items) private pure returns (bytes memory) {
+        if (items.length <= 55) return bytes.concat(bytes1(uint8(0xc0 + items.length)), items);
+        return bytes.concat(hex"f8", bytes1(uint8(items.length)), items);
+    }
+
+    /// @notice Big-endian byte representation of `v` with leading zero bytes stripped.
+    function _trim(uint256 v) private pure returns (bytes memory out) {
+        if (v == 0) return out;
+        uint256 len;
+        uint256 t = v;
+        while (t != 0) {
+            len++;
+            t >>= 8;
+        }
+        out = new bytes(len);
+        for (uint256 i; i < len; i++) {
+            out[len - 1 - i] = bytes1(uint8(v >> (8 * i)));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Security hardening for the **contract-asset emergency exit** feature (\`src/emergency-exit/\` + \`src/libraries/EmergencyExitProof.sol\`), following a focused security audit. Fixes two HIGH vulnerabilities, two MEDIUM issues, and two correctness defects. Each fix is an atomic commit on top of a pre-audit baseline so the security change is reviewable in isolation.

## Findings & fixes

| Sev | Issue | Fix |
|-----|-------|-----|
| 🔴 HIGH | **Replay / missing nullifier** — \`exitViaProof\` keyed the double-claim guard on a caller-supplied \`blockNumber\` while the L2 balance is never consumed, so the same balance could be re-proven at every finalized state root and claimed once per block → reserve drain. | Remove \`blockNumber\` from \`ExitProofRequest\`; add guardian-only \`declareEmergency(blockNumber)\` pinning a single \`emergencyBlockNumber\`; key the guard on \`(l2Token, user)\`. |
| 🔴 HIGH | **Storage value over-claim** (found during fix) — the storage leaf stores \`RLP(slotValue)\`; \`MerkleTrie.get\` returns that blob, which was parsed directly as an integer. For any balance ≥ 0x80 the RLP length-prefix byte inflated the value → over-claim. | RLP-decode the value one extra level (\`RLPReader.readBytes\`) before parsing. |
| 🟠 MEDIUM | **\`emergencyBlockNumber\` overwrite** — guardian could call \`declareEmergency()\` multiple times, silently invalidating in-flight proofs and rotating the snapshot to a new block (bypasses the replay guard via re-keying). | Add set-once guard: \`if (emergencyBlockNumber != 0) revert EmergencyAlreadyDeclared()\`. |
| 🟠 MEDIUM | **Non-standard ERC-20 \`approve\`** — \`EmergencyExitableBase\` called bare \`IERC20.approve()\` while \`using SafeERC20 for IERC20\` was declared but unused. Tokens like USDT return \`void\` from \`approve\`, causing revert on every Force TX exit. | Changed to \`safeApprove()\`. |
| 🟡 Low | **Storage proof key not hashed** — proofs used the raw trie key via \`MerkleTrie\`, so legitimate \`eth_getProof\` proofs never matched the secure trie path (resolver path non-functional). | Use \`SecureMerkleTrie\` for both account and storage stages (keccak256-hashes the key). |
| 🟡 Low | **\`activateToken\` on unregistered token** — no access control + \`activatesAt == 0\` let any address be flipped active with \`l1Token == 0\`. | Add \`NotRegistered\` guard (\`rec.l1Token == address(0)\`). |
| 🟡 Low | **\`emergencyExit\` alias corruption** — unconditional \`undoL1ToL2Alias(msg.sender)\` corrupted the caller for EOA Force TX (OP aliases only L1 *contract* senders). | Use \`msg.sender\` directly as the L2 owner identity. |

## Tests

Real two-stage MPT proofs are now built in-memory (\`test/emergency-exit/MptProofBuilder.sol\`) so the proof path is exercised end-to-end (a 1e18 balance decodes exactly; over-claims revert; replay is blocked).

\`\`\`
forge test --match-path "test/emergency-exit/*"  →  40 passed, 0 failed
forge build                                       →  successful
\`\`\`

## Commits (base + per-issue)

- \`feat(emergency-exit): asset emergency exit contracts (pre-audit baseline)\`
- \`fix(emergency-exit): verify proofs with SecureMerkleTrie and RLP-decode storage value\`
- \`fix(emergency-exit): pin exits to a guardian-set snapshot block to prevent replay\`
- \`fix(emergency-exit): reject activation of unregistered tokens\`
- \`fix(emergency-exit): use msg.sender as the L2 owner identity in emergencyExit\`
- \`fix(emergency-exit): prevent emergency re-declaration and use safeApprove\`

## Notes for reviewers

- **ABI change**: \`ExitProofRequest\` no longer carries \`blockNumber\` — off-chain proof submitters/monitoring services must drop it and rely on \`emergencyBlockNumber\`.
- **Operational**: \`declareEmergency\` is the new trust anchor; guardian key management gates the resolver path. The snapshot must be the emergency *freeze* height, and reserve sizing must assume the full eligible balance at that height. \`declareEmergency\` is now irreversible (set-once), so the guardian must confirm the block has a valid finalized state root before calling.
- Exit is currently all-or-nothing (no partial claims); a cumulative-cap variant is noted in the audit if partial withdrawals are later required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)